### PR TITLE
Add top margin to all headings (h1 through h6)

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -23,7 +23,11 @@ th, td { /* ns 4 */
   font-family: sans-serif;
 }
 
-h1, h2, h3, h4, h5, h6 { text-align: left }
+h1, h2, h3, h4, h5, h6 {
+  margin-top: 1.5em;
+  text-align: left;
+}
+
 /* background should be transparent, but WebTV has a bug */
 h1, h2, h3 { color: #005A9C; background: white }
 h1 { font: 170% sans-serif }


### PR DESCRIPTION
Following #13, I suggest this general style rule: _all heading should have blank space above as margin, for aesthetics and readability; at least 1.5&times; its own font height_.
