### PR TITLE
Add unobtrusive overlay with handy links for better navigation

### DIFF
--- a/releases/2015/base.css
+++ b/releases/2015/base.css
@@ -62,3 +62,48 @@ ul.toc, ol.toc {
  p.copyright { voice-volume: x-soft; voice-rate: x-fast; }
  dt { pause-before: 63ms; }
 }
+
+/* Navigation overlay */
+
+@media screen, handheld, tv, projection {
+
+  .nav-overlay {
+    position:         fixed;
+    bottom:           -0.5em;
+    right:            -0.5em;
+    margin:           0;
+    border:           solid 1px #e0e0e0;
+    border-radius:    0.5em;
+    padding:          0.25em 1em 0.75em 0.5em;
+    font-size:        1.5rem;
+    line-height:      1.5rem;
+    background-color: rgba(252, 252, 252, 0.8);
+  }
+
+  .nav-overlay:hover, .nav-overlay:active, .nav-overlay:focus {
+    background-color: rgba(255, 255, 255, 1);
+    border-color:     #808080;
+  }
+
+  .nav-overlay img {
+    width:            1.5rem;
+    height:           1.5rem;
+    vertical-align:   middle;
+    opacity:          0.5;
+  }
+
+  .nav-overlay img:hover, .nav-overlay img:active, .nav-overlay img:focus {
+    opacity:          1;
+  }
+
+}
+
+@media print {
+
+  .nav-overlay {
+    display:          none;
+    visibility:       hidden;
+  }
+
+}
+

--- a/releases/2015/base.css
+++ b/releases/2015/base.css
@@ -98,7 +98,7 @@ ul.toc, ol.toc {
 
 }
 
-@media print {
+@media print, braille, embossed, speech, tty {
 
   .nav-overlay {
     display:          none;

--- a/releases/2015/home.svg
+++ b/releases/2015/home.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+
+<!-- The icon can be used freely in both personal and commercial projects with no attribution required, but always appreciated. 
+You may NOT sub-license, resell, rent, redistribute or otherwise transfer the icon without express written permission from iconmonstr.com -->
+
+
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+
+	 width="512px" height="512px" viewBox="0 0 512 512" enable-background="new 0 0 512 512" xml:space="preserve">
+
+<path id="home-6-icon" d="M256,69.972L50,275.815h42.507v166.213h326.985V275.815H462L256,69.972z M374.492,397.028h-73.767v-86.495
+
+	h-89.451v86.495h-73.768V251.99L256,133.587l118.492,118.402V397.028z"/>
+
+</svg>
+

--- a/releases/2015/toc.svg
+++ b/releases/2015/toc.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- License Agreement at http://iconmonstr.com/license/ -->
+
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="512px" height="512px" viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
+<path id="sitemap-2-icon" d="M180,372v60H80v-60H180z M210,342H50v120h160V342z M432,372v60H332v-60H432z M462,342H302v120h160V342z
+	 M306,80v60H206V80H306z M336,50H176v120h160V50z M271,242v-52h-30v52H115v79.917h30V272h222v49.917h30V242H271z"/>
+</svg>


### PR DESCRIPTION
This tries to fix #21.

Once these changes are added to the base CSS, docs including this snippet:

``` html
<div class="nav-overlay">
    <a href="#"><img src="[path]/home" alt="Home icon"></a>
    <a href="#toc"><img src="[path]/toc" alt="TOC icon"></a>
</div>
```

will show this overlay at the bottom-right corner:

![overlay](https://cloud.githubusercontent.com/assets/1016538/8644022/3c9afa0c-2976-11e5-8d1e-5746b55a5654.png)

![overlay2](https://cloud.githubusercontent.com/assets/1016538/8644024/431e9b2c-2976-11e5-9928-56c161866a41.png)

(This last screenshot shows the effect when hovering over the overlay, and over one particular icon.)

The first icon takes you to the very top of the document. The one on the right-hand side takes you to the TOC. This assumes that there is an element `id="toc"` or `name="toc"` marking the beginning of the table of contents.

If there were other TOCs, or even different sections or &ldquo;bookmarks&rdquo;, that the editors want to highlight (to make it easier for readers to navigate to them), it would be trivial to include them, too. For example, [`http://www.w3.org/TR/CSS21`](http://www.w3.org/TR/CSS21) has two TOCs: [`#minitoc`](http://www.w3.org/TR/CSS21/#minitoc) and [`#toc`](http://www.w3.org/TR/CSS21/#toc). In that case, we simply would need to include more `<a href="#[fragment-id]"><img src="[img]" alt="[desc]"></a>` elements inside `.nav-overlay`.

This overlay isn't rendered when it doesn't make sense&nbsp;&mdash;&nbsp;eg when printing the document, or on braille UAs.
