### PR TITLE
Fix low vision related issues in .toc

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -961,7 +961,7 @@ Possible extra rowspan handling
 
 	/* ToC not indented until third level, but font style & margins show hierarchy */
 	.toc > li             { font-weight: bold; }
-	.toc > li li          { }
+	.toc > li li          { font-weight: normal;}
 	.toc > li li li       { font-size: 95%; }
 	.toc > li li li li    { font-size: 90%; }
 	.toc > li li li li li { font-size: 85%; }

--- a/src/base.css
+++ b/src/base.css
@@ -960,25 +960,25 @@ Possible extra rowspan handling
 	}
 
 	/* ToC not indented until third level, but font style & margins show hierarchy */
-	.toc > li             { font-weight: bold;   }
-	.toc > li li          { font-weight: normal; }
-	.toc > li li li       { font-style:  italic; }
-	.toc > li li li li    { font-style:  normal; }
-	.toc > li li li li li { font-style:  italic;
-	                        font-size:   85%;    }
+	.toc > li             { font-weight: bold; }
+	.toc > li li          { }
+	.toc > li li li       { font-size: 95%; }
+	.toc > li li li li    { font-size: 90%; }
+	.toc > li li li li li { font-size: 85%; }
 
 	.toc > li             { margin: 1.5rem 0;    }
 	.toc > li li          { margin: 0.3rem 0;    }
 	.toc > li li li       { margin-left: 2rem;   }
 
 	/* Section numbers in a column of their own */
-	:not(li) > .toc {
+	/*:not(li) > .toc {
 		margin-left: 5em;
-	}
+	}*/
 
 	.toc .secno {
 		float: left;
-		width: 4rem;
+		/*width: 4rem;*/
+		margin-right: .75rem;
 		white-space: nowrap;
 	}
 	.toc > li li li li .secno {
@@ -988,14 +988,14 @@ Possible extra rowspan handling
 		font-size: 100%;
 	}
 
-	:not(li) > .toc              { margin-left:  5rem; }
+/*	:not(li) > .toc              { margin-left:  5rem; }
 	.toc .secno                  { margin-left: -5rem; }
 	.toc > li li li .secno       { margin-left: -7rem; }
 	.toc > li li li li .secno    { margin-left: -9rem; }
-	.toc > li li li li li .secno { margin-left: -11rem; }
+	.toc > li li li li li .secno { margin-left: -11rem; }*/
 
 	/* Tighten up indentation in narrow ToCs */
-	@media (max-width: 30em) {
+	/*@media (max-width: 30em) {
 		:not(li) > .toc              { margin-left:  4rem; }
 		.toc .secno                  { margin-left: -4rem; }
 		.toc > li li li              { margin-left:  1rem; }
@@ -1016,7 +1016,7 @@ Possible extra rowspan handling
 	body.toc-sidebar #toc .toc > li li li              { margin-left:  1rem; }
 	body.toc-sidebar #toc .toc > li li li .secno       { margin-left: -5rem; }
 	body.toc-sidebar #toc .toc > li li li li .secno    { margin-left: -6rem; }
-	body.toc-sidebar #toc .toc > li li li li li .secno { margin-left: -7rem; }
+	body.toc-sidebar #toc .toc > li li li li li .secno { margin-left: -7rem; }*/
 
 	.toc li {
 		clear: both;


### PR DESCRIPTION
This should fix some issues that @slhenry brought up in issue #82. While stylistically pleasing, the disjoint section numbers and titles in the toc do provide an additional cognitive load. Italics are hard to read for many people, including people with disabilities. Instead I used font-size changes to differentiate between levels.

Preview: http://yatil.github.io/tr-design/src/sample.html

@slhenry Can you please double-check that this is solving the issues?
