### PR TITLE
Allow .algorithm to go on a <div> wrapper

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -408,7 +408,8 @@
 	}
 
 	/* Style for algorithms */
-	ol.algorithm ol:not(.algorithm) {
+	ol.algorithm ol:not(.algorithm),
+	.algorithm > ol ol:not(.algorithm) {
 	 border-left: 0.5em solid #DEF;
 	}
 


### PR DESCRIPTION
When using Markdown-style lists in Bikeshed, there's no way to add classes to the `<ol>` that gets generated. The usual practice in Bikeshed is to allow the class on an ancestor, so you can just use a wrapper `<div>`, but the styling here didn't allow that. My fix allows an immediate parent to have the .algorithm class instead.
