### PR TITLE
Fix flickering on “collapse sidebar” link when hovering (?)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,5 +5,5 @@ For more significant changes to the visual styles,
 discussion on spec-prod@w3.org is encouraged to get feedback and consensus.
 (Think of it as a design critique.)
 
-**Do not commit directly to any the common branches** (`gh-pages` and `2016` at the time of writing) unless you are the *Design Point Person* for the project.
+**Do not commit directly to any of the common branches** (`gh-pages` and `2016` at the time of writing) unless you are the *Design Point Person* for the project.
 Instead, fork the desired branch and submit a pull request.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For more significant changes to the visual styles,
 discussion on spec-prod@w3.org is encouraged to get feedback and consensus.
 (Think of it as a design critique.)
 
-**Do not commit directly to any the common branches** (`gh-pages` and `2016` at the time of writing) unless you are the *Design Point Person* for the project.
+**Do not commit directly to any of the common branches** (`gh-pages` and `2016` at the time of writing) unless you are the *Design Point Person* for the project.
 Instead, fork the desired branch and submit a pull request.
 
 ## Guidelines for a proper design

--- a/src/base.css
+++ b/src/base.css
@@ -514,6 +514,9 @@
 		padding: 0 1px 0;
 		margin: 0 -1px 0;
 	}
+	a#toc-toggle {
+		color: #034575;
+	}
 	a:visited {
 		border-bottom-color: #BBB;
 	}

--- a/src/fixup.js
+++ b/src/fixup.js
@@ -69,7 +69,7 @@
       /* This should probably be a button, but appearance isn't standards-track.*/
     toggle.id = 'toc-toggle';
     toggle.class = 'toc-toggle';
-    toggle.href = '#toc';
+    toggle.style = 'cursor: pointer;';
     toggle.innerHTML = collapseSidebarText;
 
     sidebarMedia.addListener(autoToggle);


### PR DESCRIPTION
Strange as it sounds, I think the bug is related to the grey overlay that both Chrom* and FF display at the bottom left when hovering over a hyperlink, showing the URL in the `href` attribute of the link.

This PR removes the `href` attribute from `a#toc-toggle`, and fakes a proper link by setting the right `cursor` and colour. That solves it for me in both FF and Chrom*.

Is this too much of a hack? Are the side-effects for semantics and a11y too bad?

Fixes #121.