### PR TITLE
use fixup.js to display the outdated warning if necessary

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -1111,6 +1111,10 @@ a#outdated-note:hover {
 	text-align:center;
 }
 
+.outdated-warning span {
+	display: block;
+}
+
 .outdated-collapsed {
 	bottom: 0;
 	border-radius: 0;

--- a/src/base.css
+++ b/src/base.css
@@ -51,6 +51,8 @@
  *   - .head for the header
  *   - .copyright for the copyright
  *
+ * Outdated warning for old specs
+ *
  * Miscellaneous
  *   - .overlarge for things that should be as wide as possible, even if
  *     that overflows the body text area. This can be used on an item or
@@ -1066,6 +1068,56 @@ Possible extra rowspan handling
 		font-weight: bold;
 	}
 
+/** Outdated warning **********************************************************/
+
+a#outdated-note {
+  color: white;
+}
+
+a#outdated-note:hover {
+	background: transparent;
+}
+
+.outdated-spec {
+	background-color: rgba(0,0,0,0.5);
+}
+
+.outdated-warning {
+	position: fixed;
+	bottom: 50%;
+	left: 0;
+	right: 0;
+	margin: 0 auto;
+	width: 50%;
+	background: maroon;
+	color: white;
+	border-radius: 1em;
+	box-shadow: 0 0 1em red;
+	padding: 2em;
+	text-align: center;
+	z-index: 2;
+}
+
+.outdated-warning input {
+	position: absolute;
+	top: 0;
+	right:0;
+	margin: 0;
+	border: 0;
+	padding: 0.25em 0.5em;
+	background: transparent;
+	color: black;
+	font:1em sans-serif;
+	text-align:center;
+}
+
+.outdated-collapsed {
+	bottom: 0;
+	border-radius: 0;
+	width: 100%;
+	padding: 0;
+}
+
 /******************************************************************************/
 /*                                    Print                                   */
 /******************************************************************************/
@@ -1078,6 +1130,16 @@ Possible extra rowspan handling
 		/* Serif for print. */
 		body {
 			font-family: serif;
+		}
+
+		.outdated-warning {
+			position: absolute;
+			border-style: solid;
+			border-color: red;
+		}
+
+		.outdated-warning input {
+			display: none;
 		}
 	}
 	@page {

--- a/src/base.css
+++ b/src/base.css
@@ -1071,7 +1071,7 @@ Possible extra rowspan handling
 /** Outdated warning **********************************************************/
 
 a#outdated-note {
-  color: white;
+	color: white;
 }
 
 a#outdated-note:hover {

--- a/src/base.css
+++ b/src/base.css
@@ -1098,7 +1098,7 @@ a#outdated-note:hover {
 	z-index: 2;
 }
 
-.outdated-warning input {
+.outdated-warning button {
 	position: absolute;
 	top: 0;
 	right:0;

--- a/src/fixup.js
+++ b/src/fixup.js
@@ -1,8 +1,9 @@
 /******************************************************************************
  *                 JS Extension for the W3C Spec Style Sheet                  *
  *                                                                            *
- * This code handles some fixup to improve the table of contents.             *
- * It is intended to be a very simple script for 2016.                        *
+ * This code handles:                                                         *
+ * - some fixup to improve the table of contents                              *
+ * - the obsolete warning on outdated specs                                   *
  ******************************************************************************/
 (function() {
   "use strict";
@@ -139,4 +140,78 @@
     }
   }
 
+  /* Deprecation warning */
+  var request = new XMLHttpRequest();
+  request.open('GET', '//www.w3.org/TR/tr-outdated-spec.json', true);
+  request.onload = function() {
+    if (request.status >= 200 && request.status < 400) {
+      var outdatedSpecs = JSON.parse(request.responseText);
+      const pathname = window.location.pathname;
+      var spec = Object.keys(outdatedSpecs).filter(function(k) {return pathname.indexOf(k) === 0;}).shift();
+      if (spec) {
+        var css = 'a#deprecationnote:hover{ background-color: transparent }'
+        ,   style = document.createElement('style');
+        if (style.styleSheet) {
+          style.styleSheet.cssText = css;
+        } else {
+          style.appendChild(document.createTextNode(css));
+        }
+        document.getElementsByTagName('head')[0].appendChild(style);
+        var nodes = document.querySelectorAll("body, h1, h2, h3");
+        for (var i = 0; i < nodes.length; i++) {
+          nodes[i].setAttribute("style", "background-color: rgba(0,0,0,0.5);");
+        }
+        var node = document.createElement("p");
+        node.className = "outdatedwarning";
+        var outdatedValue = "bottom:50%; left:0; right:0; margin:0 auto 0 auto; width:50%; background:maroon; color:white; border-radius:1em; box-shadow:0 0 1em red; padding:2em; text-align:center; z-index:2;";
+        node.style.cssText = "position:fixed; " + outdatedValue;
+
+        var warning = '<strong>This version is outdated!</strong><div>For the latest version, please look at the <a id="deprecationnote" style="color:white" href="' + outdatedSpecs[spec] + '"> ' + outdatedSpecs[spec] + '</a>.</div><input onclick="collapseWarning(false)" style="margin:0; border:0; padding:0.25em 0.5em; background:transparent; color:black; position:absolute; top:0em; right:0; font:1.25em sans-serif; text-align:center;" type="button" value="&#9662; collapse">';
+        node.innerHTML = warning;
+
+        document.querySelector("body").appendChild(node);
+
+        /* Apply a slightly different style for print media */
+        var mediaQueryList = window.matchMedia('print');
+        mediaQueryList.addListener(function(mql) {
+          if (mql.matches) {
+            node.style.cssText = "position:absolute; border-style:solid; border-color:red; " + outdatedValue;
+            node.innerHTML = '<strong>This version is outdated!</strong><div>For the latest version, please look at the <a id="deprecationnote" style="color:white" href="' + outdatedSpecs[spec] + '"> ' + outdatedSpecs[spec] + '</a>.</div>';
+          } else {
+            node.style.cssText = "position:fixed; " + outdatedValue;
+            node.innerHTML = warning;
+          }
+        });
+      }
+    } else {
+      console.error("Error downloading https://www.w3.org/TR/tr-outdated-spec.json");
+    }
+  };
+
+  request.onerror = function() {
+    console.error("Error downloading https://www.w3.org/TR/tr-outdated-spec.json");
+  };
+
+  request.send();
 })();
+
+function collapseWarning(details) {
+  var node = document.querySelector(".outdatedwarning")
+  ,   button = document.querySelector(".outdatedwarning input")
+  ,   opacity;
+  if (details) {
+    node.style.cssText = "position:fixed; bottom:50%; left:0; right:0; margin:0 auto 0 auto; width:50%; background:maroon; color:white; border-radius:1em; box-shadow:0 0 1em red; padding:2em; text-align:center; z-index:2;";
+    button.value = '\u25BE collapse';
+    button.onclick = function() {collapseWarning(false)};
+    opacity = "0.5";
+  } else {
+    node.style.cssText = "z-index:2; bottom:0; left:0; right:0; border-radius:0; position:fixed; margin:0 auto; background:maroon; color:white; text-align:center;";
+    button.value = '\u25B4 expand';
+    button.onclick = function() {collapseWarning(true)};
+    opacity = "0";
+  }
+  var nodes = document.querySelectorAll("body, h1, h2, h3");
+  for (var i = 0; i < nodes.length; i++) {
+    nodes[i].setAttribute("style", "background-color:rgba(0,0,0," + opacity + ");");
+  }
+}

--- a/src/fixup.js
+++ b/src/fixup.js
@@ -145,19 +145,31 @@
 
   request.open('GET', '//www.w3.org/TR/tr-outdated-spec');
   request.onload = function() {
-    if (request.status >= 200 && request.status < 400) {
-      var currentSpec = JSON.parse(request.responseText);
-      if (currentSpec) {
-        document.body.classList.add('outdated-spec');
-        var node = document.createElement("p");
-        node.classList.add("outdated-warning");
-
-        var warning = '<strong>' + currentSpec.header + '</strong><div>' + currentSpec.warning + '<a id="outdated-note" href="' + currentSpec.latestUrl + '"> ' + currentSpec.latestUrl + '</a>.</div><input onclick="collapseWarning(false)" type="button" value="&#9662; collapse">';
-        node.innerHTML = warning;
-
-        document.querySelector("body").appendChild(node);
-      }
+    if (request.status < 200 && request.status > 400) {
+      return;
     }
+    try {
+      var currentSpec = JSON.parse(request.responseText);
+    } catch (err) {
+      console.error(err);
+      return;
+    }
+    document.body.classList.add('outdated-spec');
+    var node = document.createElement("p");
+    node.classList.add("outdated-warning");
+
+    var warning =
+      "<strong>" +
+      currentSpec.header +
+      "</strong><span>" +
+      currentSpec.warning +
+      '<a id="outdated-note" href="' +
+      currentSpec.latestUrl +
+      '"> ' +
+      currentSpec.latestUrl +
+      '</a>.</span><input onclick="collapseWarning(false)" type="button" value="&#9662; collapse">';
+    node.innerHTML = warning;
+    document.body.appendChild(node);
   };
 
   request.onerror = function() {

--- a/src/fixup.js
+++ b/src/fixup.js
@@ -148,69 +148,37 @@
     if (request.status >= 200 && request.status < 400) {
       var currentSpec = JSON.parse(request.responseText);
       if (currentSpec) {
-        var css = 'a#deprecationnote:hover{ background-color: transparent }'
-        ,   style = document.createElement('style');
-        if (style.styleSheet) {
-          style.styleSheet.cssText = css;
-        } else {
-          style.appendChild(document.createTextNode(css));
-        }
-        document.getElementsByTagName('head')[0].appendChild(style);
-        var nodes = document.querySelectorAll("body, h1, h2, h3");
-        for (var i = 0; i < nodes.length; i++) {
-          nodes[i].setAttribute("style", "background-color: rgba(0,0,0,0.5);");
-        }
+        document.body.classList.add('outdated-spec');
         var node = document.createElement("p");
-        node.className = "outdatedwarning";
-        var outdatedValue = "bottom:50%; left:0; right:0; margin:0 auto 0 auto; width:50%; background:maroon; color:white; border-radius:1em; box-shadow:0 0 1em red; padding:2em; text-align:center; z-index:2;";
-        node.style.cssText = "position:fixed; " + outdatedValue;
+        node.classList.add("outdated-warning");
 
-        var warning = '<strong>This version is outdated!</strong><div>For the latest version, please look at the <a id="deprecationnote" style="color:white" href="' + currentSpec + '"> ' + currentSpec + '</a>.</div><input onclick="collapseWarning(false)" style="margin:0; border:0; padding:0.25em 0.5em; background:transparent; color:black; position:absolute; top:0em; right:0; font:1.25em sans-serif; text-align:center;" type="button" value="&#9662; collapse">';
+        var warning = '<strong>This version is outdated!</strong><div>For the latest version, please look at the <a id="outdated-note" href="' + currentSpec + '"> ' + currentSpec + '</a>.</div><input onclick="collapseWarning(false)" type="button" value="&#9662; collapse">';
         node.innerHTML = warning;
 
         document.querySelector("body").appendChild(node);
-
-        /* Apply a slightly different style for print media */
-        var mediaQueryList = window.matchMedia('print');
-        mediaQueryList.addListener(function(mql) {
-          if (mql.matches) {
-            node.style.cssText = "position:absolute; border-style:solid; border-color:red; " + outdatedValue;
-            node.innerHTML = '<strong>This version is outdated!</strong><div>For the latest version, please look at the <a id="deprecationnote" style="color:white" href="' + currentSpec + '"> ' + currentSpec + '</a>.</div>';
-          } else {
-            node.style.cssText = "position:fixed; " + outdatedValue;
-            node.innerHTML = warning;
-          }
-        });
       }
-    } else {
-      console.error("Error downloading https://www.w3.org/TR/tr-outdated-spec.json");
     }
   };
 
   request.onerror = function() {
-    console.error("Error downloading https://www.w3.org/TR/tr-outdated-spec.json");
+    console.error("Request to https://www.w3.org/TR/tr-outdated-spec failed.");
   };
 
   request.send();
 })();
 
 function collapseWarning(details) {
-  var node = document.querySelector(".outdatedwarning")
-  ,   button = document.querySelector(".outdatedwarning input")
-  ,   opacity;
+  var node = document.querySelector(".outdated-warning")
+  ,   button = document.querySelector(".outdated-warning input");
   if (details) {
-    node.style.cssText = "position:fixed; bottom:50%; left:0; right:0; margin:0 auto 0 auto; width:50%; background:maroon; color:white; border-radius:1em; box-shadow:0 0 1em red; padding:2em; text-align:center; z-index:2;";
+    node.classList.remove("outdated-collapsed");
     button.value = '\u25BE collapse';
+    document.body.classList.add('outdated-spec');
     button.onclick = function() {collapseWarning(false)};
-    opacity = "0.5";
   } else {
-    node.style.cssText = "z-index:2; bottom:0; left:0; right:0; border-radius:0; position:fixed; margin:0 auto; background:maroon; color:white; text-align:center;";
+    node.classList.add("outdated-collapsed");
     button.value = '\u25B4 expand';
+    document.body.classList.remove('outdated-spec');
     button.onclick = function() {collapseWarning(true)};
-    opacity = "0";
-  }
-  var nodes = document.querySelectorAll("body, h1, h2, h3");
-  for (var i = 0; i < nodes.length; i++) {
-    nodes[i].setAttribute("style", "background-color:rgba(0,0,0," + opacity + ");");
   }
 }

--- a/src/fixup.js
+++ b/src/fixup.js
@@ -185,15 +185,9 @@
       return function collapseWarning(event) {
         var button = event.target;
         isOpen = !isOpen;
-        if (isOpen) {
-          node.classList.remove("outdated-collapsed");
-          button.innerText = '\u25BE collapse';
-          document.body.classList.add("outdated-spec");
-          return;
-        }
-        node.classList.add("outdated-collapsed");
-        button.innerText = '\u25B4 expand';
-        document.body.classList.remove("outdated-spec");
+        node.classList.toggle("outdated-collapsed");
+        document.body.classList.toggle("outdated-spec");
+        button.innerText = (isOpen) ? '\u25BE collapse' : '\u25B4 expand';
       }
     }
     document.body.appendChild(node);

--- a/src/fixup.js
+++ b/src/fixup.js
@@ -152,7 +152,7 @@
         var node = document.createElement("p");
         node.classList.add("outdated-warning");
 
-        var warning = '<strong>This version is outdated!</strong><div>For the latest version, please look at the <a id="outdated-note" href="' + currentSpec + '"> ' + currentSpec + '</a>.</div><input onclick="collapseWarning(false)" type="button" value="&#9662; collapse">';
+        var warning = '<strong>' + currentSpec.header + '</strong><div>' + currentSpec.warning + '<a id="outdated-note" href="' + currentSpec.latestUrl + '"> ' + currentSpec.latestUrl + '</a>.</div><input onclick="collapseWarning(false)" type="button" value="&#9662; collapse">';
         node.innerHTML = warning;
 
         document.querySelector("body").appendChild(node);

--- a/src/fixup.js
+++ b/src/fixup.js
@@ -142,13 +142,12 @@
 
   /* Deprecation warning */
   var request = new XMLHttpRequest();
-  request.open('GET', '//www.w3.org/TR/tr-outdated-spec.json', true);
+
+  request.open('GET', '//www.w3.org/TR/tr-outdated-spec');
   request.onload = function() {
     if (request.status >= 200 && request.status < 400) {
-      var outdatedSpecs = JSON.parse(request.responseText);
-      const pathname = window.location.pathname;
-      var spec = Object.keys(outdatedSpecs).filter(function(k) {return pathname.indexOf(k) === 0;}).shift();
-      if (spec) {
+      var currentSpec = JSON.parse(request.responseText);
+      if (currentSpec) {
         var css = 'a#deprecationnote:hover{ background-color: transparent }'
         ,   style = document.createElement('style');
         if (style.styleSheet) {
@@ -166,7 +165,7 @@
         var outdatedValue = "bottom:50%; left:0; right:0; margin:0 auto 0 auto; width:50%; background:maroon; color:white; border-radius:1em; box-shadow:0 0 1em red; padding:2em; text-align:center; z-index:2;";
         node.style.cssText = "position:fixed; " + outdatedValue;
 
-        var warning = '<strong>This version is outdated!</strong><div>For the latest version, please look at the <a id="deprecationnote" style="color:white" href="' + outdatedSpecs[spec] + '"> ' + outdatedSpecs[spec] + '</a>.</div><input onclick="collapseWarning(false)" style="margin:0; border:0; padding:0.25em 0.5em; background:transparent; color:black; position:absolute; top:0em; right:0; font:1.25em sans-serif; text-align:center;" type="button" value="&#9662; collapse">';
+        var warning = '<strong>This version is outdated!</strong><div>For the latest version, please look at the <a id="deprecationnote" style="color:white" href="' + currentSpec + '"> ' + currentSpec + '</a>.</div><input onclick="collapseWarning(false)" style="margin:0; border:0; padding:0.25em 0.5em; background:transparent; color:black; position:absolute; top:0em; right:0; font:1.25em sans-serif; text-align:center;" type="button" value="&#9662; collapse">';
         node.innerHTML = warning;
 
         document.querySelector("body").appendChild(node);
@@ -176,7 +175,7 @@
         mediaQueryList.addListener(function(mql) {
           if (mql.matches) {
             node.style.cssText = "position:absolute; border-style:solid; border-color:red; " + outdatedValue;
-            node.innerHTML = '<strong>This version is outdated!</strong><div>For the latest version, please look at the <a id="deprecationnote" style="color:white" href="' + outdatedSpecs[spec] + '"> ' + outdatedSpecs[spec] + '</a>.</div>';
+            node.innerHTML = '<strong>This version is outdated!</strong><div>For the latest version, please look at the <a id="deprecationnote" style="color:white" href="' + currentSpec + '"> ' + currentSpec + '</a>.</div>';
           } else {
             node.style.cssText = "position:fixed; " + outdatedValue;
             node.innerHTML = warning;

--- a/src/fixup.js
+++ b/src/fixup.js
@@ -145,7 +145,7 @@
 
   request.open('GET', '//www.w3.org/TR/tr-outdated-spec');
   request.onload = function() {
-    if (request.status < 200 && request.status > 400) {
+    if (request.status < 200 && request.status >= 400) {
       return;
     }
     try {
@@ -154,21 +154,48 @@
       console.error(err);
       return;
     }
-    document.body.classList.add('outdated-spec');
+    document.body.classList.add("outdated-spec");
     var node = document.createElement("p");
     node.classList.add("outdated-warning");
 
-    var warning =
-      "<strong>" +
-      currentSpec.header +
-      "</strong><span>" +
-      currentSpec.warning +
-      '<a id="outdated-note" href="' +
-      currentSpec.latestUrl +
-      '"> ' +
-      currentSpec.latestUrl +
-      '</a>.</span><input onclick="collapseWarning(false)" type="button" value="&#9662; collapse">';
-    node.innerHTML = warning;
+    var frag = document.createDocumentFragment();
+    var heading = document.createElement("strong");
+    heading.innerHTML = currentSpec.header;
+    frag.appendChild(heading);
+
+    var anchor = document.createElement("a");
+    anchor.id = "outdated-note";
+    anchor.href = currentSpec.latestUrl;
+    anchor.innerText = currentSpec.latestUrl + ".";
+
+    var warning = document.createElement("span");
+    warning.innerText = currentSpec.warning;
+    warning.appendChild(anchor);
+    frag.appendChild(warning);
+
+    var button = document.createElement("button");
+    var handler = makeClickHandler(node);
+    button.addEventListener("click", handler);
+    button.innerHTML = "&#9662; collapse";
+    frag.appendChild(button);
+    node.appendChild(frag);
+
+    function makeClickHandler(node) {
+      var isOpen = true;
+      return function collapseWarning(event) {
+        var button = event.target;
+        isOpen = !isOpen;
+        if (isOpen) {
+          node.classList.remove("outdated-collapsed");
+          button.innerText = '\u25BE collapse';
+          document.body.classList.add("outdated-spec");
+          return;
+        }
+        node.classList.add("outdated-collapsed");
+        button.innerText = '\u25B4 expand';
+        document.body.classList.remove("outdated-spec");
+      }
+    }
     document.body.appendChild(node);
   };
 
@@ -178,19 +205,3 @@
 
   request.send();
 })();
-
-function collapseWarning(details) {
-  var node = document.querySelector(".outdated-warning")
-  ,   button = document.querySelector(".outdated-warning input");
-  if (details) {
-    node.classList.remove("outdated-collapsed");
-    button.value = '\u25BE collapse';
-    document.body.classList.add('outdated-spec');
-    button.onclick = function() {collapseWarning(false)};
-  } else {
-    node.classList.add("outdated-collapsed");
-    button.value = '\u25B4 expand';
-    document.body.classList.remove('outdated-spec');
-    button.onclick = function() {collapseWarning(true)};
-  }
-}


### PR DESCRIPTION
Starting from Oct 1, we will display a warning on the outdated specs ([see item 3](https://lists.w3.org/Archives/Public/spec-prod/2017JulSep/0005.html)).
To avoid more pubrules requirements, that PR updates fixup.js to handle that warning.
The PR also updates the style a little bit for the print media per @fantasai's suggestion.

Feedback welcome!

cc @marcoscaceres 