### PR TITLE
remove console.error if tr-outdated-spec doesn't return anything

### DIFF
--- a/src/fixup.js
+++ b/src/fixup.js
@@ -151,7 +151,6 @@
     try {
       var currentSpec = JSON.parse(request.responseText);
     } catch (err) {
-      console.error(err);
       return;
     }
     document.body.classList.add("outdated-spec");
@@ -191,10 +190,6 @@
       }
     }
     document.body.appendChild(node);
-  };
-
-  request.onerror = function() {
-    console.error("Request to https://www.w3.org/TR/tr-outdated-spec failed.");
   };
 
   request.send();


### PR DESCRIPTION
`/TR/tr-outdated-spec` may return a 404 if the spec is not outdated or couldn't be found. That's the expected behavior so calling `console.error` is confusing.