### PR TITLE
Style and script to handle warning on edited RECs

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -1098,6 +1098,11 @@ a#outdated-note:hover {
 	z-index: 2;
 }
 
+.edited-rec-warning {
+	background: orange;
+	box-shadow: 0 0 1em;
+}
+
 .outdated-warning button {
 	position: absolute;
 	top: 0;

--- a/src/fixup.js
+++ b/src/fixup.js
@@ -158,6 +158,9 @@
       document.body.classList.add("outdated-spec");
       var node = document.createElement("p");
       node.classList.add("outdated-warning");
+      if (currentSpec.style) {
+          node.classList.add(currentSpec.style);
+      }
 
       var frag = document.createDocumentFragment();
       var heading = document.createElement("strong");


### PR DESCRIPTION
That PR updates the style and `fixup.js` to display a different warning on edited REC in progress. Here's how the warning looks like (**This is an example, html-aria is not an edited REC**)
![edited-rec](https://user-images.githubusercontent.com/1696128/34157717-33df9f70-e4dc-11e7-9241-f7a91082fb16.png)

