### PR TITLE
Avoid using rem units for line-height

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -958,7 +958,9 @@ Possible extra rowspan handling
 		/* because generated content isn't search/selectable and markers can't do multilevel yet */
 		margin:  0;
 		padding: 0;
-		line-height: 1.1rem; /* consistent spacing */
+	}
+	.toc {
+		line-height: 1.1em; /* consistent spacing */
 	}
 
 	/* ToC not indented until third level, but font style & margins show hierarchy */


### PR DESCRIPTION
Because of a bug in WebKit versions prior to Safari/iOS12, where it was not properly computing line heights defined with rem units:
https://bugs.webkit.org/show_bug.cgi?id=177585

The table of contents in the spec currently triggers this bug (inconsistently, due to the nature of the bug), making it unreadable and unusable for some users on iOS browsers or Safari.  See screenshot & discussion here: https://twitter.com/meyerweb/status/1040418347182174209

I've suggested a fix that preserves the vertical rhythm even with nested TOC items of smaller font sizes: set a line-height in em on the `ol.toc`, and then let it inherit it as a absolute value to the list items.