### PR TITLE
fix: rendering issue in Firefox.

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -516,7 +516,6 @@
 		border-bottom: 1px solid #707070;
 		/* Need a bit of extending for it to look okay */
 		padding: 0 1px 0;
-		margin: 0 -1px 0;
 	}
 	a:visited {
 		border-bottom-color: #BBB;


### PR DESCRIPTION
The -1 here is causing this in Firefox: 

<img width="809" alt="Screen Shot 2019-04-02 at 9 38 16 AM" src="https://user-images.githubusercontent.com/870154/55420710-8af8e480-552c-11e9-81d0-38e139a20e64.png">

Filed a bug on Firefox (as it works fine in Chrome and Safari):
https://bugzilla.mozilla.org/show_bug.cgi?id=1541102

But wondering if we need the -1 here? 