### PR TITLE
Mark CG-Drafts as unofficial

### DIFF
--- a/src/cg-draft.css
+++ b/src/cg-draft.css
@@ -1,9 +1,5 @@
 @import url('base.css');
 
-html {
-  background: white url(https://www.w3.org/StyleSheets/TR/2016/logos/UD-watermark);
-}
-
 @media screen and (min-width: 28em) {
     body {
         background-image: url('logos/back-cg-draft.png');
@@ -24,4 +20,12 @@ html {
         padding-top: 160px;
         background-attachment: local !important;
     };
+}
+
+body {
+    background-color: transparent;
+}
+
+html {
+    background: white url(https://www.w3.org/StyleSheets/TR/2016/logos/UD-watermark);
 }

--- a/src/cg-draft.css
+++ b/src/cg-draft.css
@@ -1,5 +1,9 @@
 @import url('base.css');
 
+html {
+  background: white url(https://www.w3.org/StyleSheets/TR/2016/logos/UD-watermark);
+}
+
 @media screen and (min-width: 28em) {
     body {
         background-image: url('logos/back-cg-draft.png');


### PR DESCRIPTION
There is significant confusion about the status of CG-Drafts in the community. We should clarify that _all_ CG-Drafts are unofficial, even if they display the W3C logo. 

Cc @AmeliaBR 