### PR TITLE
Fix .overlarge styling, especially for tables

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -1180,6 +1180,18 @@ a#outdated-note:hover {
 		margin-left: auto;
 		margin-right: auto;
 	}
+	.overlarge {
+		/* Magic to create good item positioning:
+		   "content column" is 50ems wide at max; less on smaller screens.
+		   Extra space (after ToC + content) is empty on the right.
+
+		   1. When item < content column, centers item in column.
+		   2. When content < item < available, left-aligns.
+		   3. When item > available, fills available and is scrollable.
+		*/ 
+		display: grid;
+		grid-template-columns: minmax(0, 50em);
+	}
 	.overlarge > table {
 		/* limit preferred width of table */
 		max-width: 50em;
@@ -1189,7 +1201,6 @@ a#outdated-note:hover {
 
 	@media (min-width: 55em) {
 		.overlarge {
-			margin-left: calc(13px + 26.5rem - 50vw);
 			margin-right: calc(13px + 26.5rem - 50vw);
 			max-width: none;
 		}
@@ -1197,14 +1208,12 @@ a#outdated-note:hover {
 	@media screen and (min-width: 78em) {
 		body:not(.toc-inline) .overlarge {
 			/* 30.5em body padding 50em content area */
-			margin-left: calc(40em - 50vw) !important;
 			margin-right: calc(40em - 50vw) !important;
 		}
 	}
 	@media screen and (min-width: 90em) {
 		body:not(.toc-inline) .overlarge {
 			/* 4em html margin 30.5em body padding 50em content area */
-			margin-left: 0 !important;
 			margin-right: calc(84.5em - 100vw) !important;
 		}
 	}


### PR DESCRIPTION
This is copied over from Bikeshed's updated styling, now that I've confirmed it works correctly in all cases (all combinations of (a) side vs inline ToC, (b) table is small/medium/large, and (c) viewport width is narrow/medium/large.

Details of the constraints are commented in the code for posterity, but I'll pull them in here as well. Given a "main space" of 50ems or less, and an "available space" stretching from the left edge of the content column and the right edge of the viewport:

1. When item width < main width, center item in column.
2. When main width < item width < available width, left-align the item in the available space.
3. When item width > available width, make the item fill the available width and pop a scrollbar.

Some notes:

* This uses display:grid to achieve the "center in content column" behavior. In downlevel clients this instead happens to just center the item in the "available space" (which is today's behavior for *all* overlarge items...). Fixing this in downlevel clients would require an additional wrapper element, which I don't think is worthwhile.
* Removing the margin-left declarations means the available space's left edge coincides with the content columns' left edge; previous behavior had it coincide with either the ToC's right edge or the viewport's left edge, depending on if the ToC was floating or inline. I believe this produces a more attractive and predictable appearance overall; the only downside is that items which are wider than the available width but smaller than the viewport width will fill the available space (left-aligning with the main column) and have a scrollbar, rather than centering in the viewport.  This is only meaningfully visible when the ToC is inline, and is rare overall, and I think the behavior when it's between the main width and available width (left-aligning in available space) is better than centering in the viewport anyway.