### PR TITLE
Restore underlines to links in headers

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -541,7 +541,7 @@
 	.head p:not(.copyright) > a,
 	.head > a:first-child {
 		border: none;
-		text-decoration: none;
+		text-decoration: underline;
 		background: transparent;
 	}
 


### PR DESCRIPTION
This is necessary to conform to WCAG 2.1 SC 1.4.1 Use of Color
https://www.w3.org/TR/WCAG21/#use-of-color. Issue filed as wcag/1048.