### PR TITLE
Make the two selectors exactly parallel.

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -1038,7 +1038,7 @@ Possible extra rowspan handling
 	ul.index ul,
 	ul.index dl { font-size: smaller; }
 	@media not print {
-		ul.index li span {
+		ul.index li a + span {
 			white-space: nowrap;
 			color: transparent;
 		}


### PR DESCRIPTION
The first selector is overmatching right now in the "Terms Defined By Reference" index, requiring Bikeshed to hack around it.