### PR TITLE
Darken the "Example N" and "Issue N" heading text colors to hit AAA

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -643,7 +643,7 @@
 		overflow: auto;
 	}
 	.issue::before, .issue > .marker {
-		color: #AE1E1E;
+		color: #831616;
 		padding-right: 1em;
 		text-transform: uppercase;
 	}
@@ -661,7 +661,7 @@
 	}
 	.example::before, .example > .marker {
 		text-transform: uppercase;
-		color: #827017;
+		color: #574b0f;
 		min-width: 7.5em;
 		display: block;
 	}


### PR DESCRIPTION
The colors of the "Example N" and "Issue N" text "headings" only hit AA contrast against the example and issue backgrounds.  Darkening their HSL color from 30%->20% (for example) and 40%->30% (for issue) lightness hits AAA, while maintaining a similar colored appearance to the current colors.

This fixes #169.