### PR TITLE
clicking outside the warning collapses it

### DIFF
--- a/src/fixup.js
+++ b/src/fixup.js
@@ -217,6 +217,12 @@
         }
       }
 
+      window.onclick = function(event) {
+        if (!node.contains(event.target) && !node.classList.contains("outdated-collapsed")) {
+          button.click();
+        }
+      }
+
       document.addEventListener("focus", function(event) {
         var isCollapsed = node.classList.contains("outdated-collapsed");
         var containsTarget = node.contains(event.target);

--- a/src/fixup.js
+++ b/src/fixup.js
@@ -217,11 +217,11 @@
         }
       }
 
-      window.onclick = function(event) {
+      window.addEventListener("click", function(event) {
         if (!node.contains(event.target) && !node.classList.contains("outdated-collapsed")) {
           button.click();
         }
-      }
+      });
 
       document.addEventListener("focus", function(event) {
         var isCollapsed = node.classList.contains("outdated-collapsed");


### PR DESCRIPTION
@fantasai mentioned that it would be great to see the outdated warning collapse if one clicks outside of it.
