### PR TITLE
Centralize all colors into variables

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -295,7 +295,7 @@
 			background: var(--tocnav-hover-bg);
 		}
 		#toc-nav > a:active {
-			color: #C00;
+			color: #c00;
 			color: var(--tocnav-active-text);
 			background: white;
 			background: var(--tocnav-active-bg);
@@ -439,7 +439,7 @@
 	}
 
 	h1, h2, h3 {
-		color: #005A9C;
+		color: #005a9c;
 		color: var(--heading-text);
 	}
 
@@ -515,7 +515,7 @@
 	/* Style for algorithms */
 	ol.algorithm ol:not(.algorithm),
 	.algorithm > ol ol:not(.algorithm) {
-	 border-left: 0.5em solid #DEF;
+	 border-left: 0.5em solid #def;
 	 border-left: 0.5em solid var(--algo-border);
 	}
 
@@ -643,7 +643,7 @@
 	a:visited {
 		color: #034575;
 		color: var(--a-visited-text);
-		border-bottom-color: #BBB;
+		border-bottom-color: #bbb;
 		border-bottom-color: var(--a-visited-underline);
 	}
 
@@ -657,9 +657,9 @@
 		margin-bottom: -2px;
 	}
 	a[href]:active {
-		color: #C00;
+		color: #c00;
 		color: var(--a-active-text);
-		border-color: #C00;
+		border-color: #c00;
 		border-color: var(--a-active-underline);
 	}
 
@@ -776,9 +776,9 @@
 /** Open issue ****************************************************************/
 
 	.issue {
-		border-color: #E05252;
+		border-color: #e05252;
 		border-color: var(--issue-border);
-		background: #FBE9E9;
+		background: #fbe9e9;
 		background: var(--issue-bg);
 		color: black;
 		color: var(--issue-text);
@@ -795,9 +795,9 @@
 /** Example *******************************************************************/
 
 	.example {
-		border-color: #E0CB52;
+		border-color: #e0cb52;
 		border-color: var(--example-border);
-		background: #FCFAEE;
+		background: #fcfaee;
 		background: var(--example-bg);
 		color: black;
 		color: var(--example-text);
@@ -815,9 +815,9 @@
 /** Non-normative Note ********************************************************/
 
 	.note {
-		border-color: #52E052;
+		border-color: #52e052;
 		border-color: var(--note-border);
-		background: #E9FBE9;
+		background: #e9fbe9;
 		background: var(--note-bg);
 		color: black;
 		color: var(--note-text);
@@ -844,7 +844,7 @@
 		border-color: orange;
 		border-color: var(--advisement-border);
 		border-style: none solid;
-		background: #FFEECC;
+		background: #fec;
 		background: var(--advisement-bg);
 		color: black;
 		color: var(--advisement-text);
@@ -854,7 +854,7 @@
 		text-align: center;
 	}
 	.advisement::before, .advisement > .marker {
-		color: #B35F00;
+		color: #b35f00;
 		color: var(--advisementheading-text);
 	}
 
@@ -904,10 +904,10 @@
 
 	.def {
 		padding: .5em 1em;
-		background: #DEF;
+		background: #def;
 		background: var(--def-bg);
 		margin: 1.2em 0;
-		border-left: 0.5em solid #8CCBF2;
+		border-left: 0.5em solid #8ccbf2;
 		border-left: 0.5em solid var(--def-border);
 		color: black;
 		color: var(--def-text);
@@ -1107,7 +1107,7 @@ Possible extra rowspan handling
 		/* Reverse color scheme */
 		color: black;
 		color: var(--toclink-text);
-		border-color: #3980B5;
+		border-color: #3980b5;
 		border-color: var(--toclink-underline);
 	}
 	.toc a:visited {

--- a/src/base.css
+++ b/src/base.css
@@ -64,6 +64,111 @@
  *
  ******************************************************************************/
 
+
+/******************************************************************************/
+/*                                  Colors                                    */
+/******************************************************************************/
+
+/* Any --text-* not paired with a --bg-* is assumed to have a transparent bg */
+:root {
+	--text: black;
+	--bg: white;
+
+	--bg-logo: #1a5e9a;
+	--bg-logo-active: #c00;
+
+	--text-tocnav-normal: #707070;
+	--bg-tocnav-normal: var(--bg);
+	--text-tocnav-hover: var(--text-tocnav-normal);
+	--bg-tocnav-hover: #f8f8f8;
+	--text-tocnav-active: #c00;
+	--bg-tocnav-active: var(--bg-tocnav-normal);
+
+	--text-tocsidebar: var(--text);
+	--bg-tocsidebar: #f7f8f9;
+	--shadow-tocsidebar: rgba(0,0,0,.1);
+	--text-tocsidebar-heading: hsla(203,20%,40%,.7);
+
+	--text-toclink: black;
+	--underline-toclink: #3980b5;
+	--text-toclink-visited: var(--text-toclink);
+	--underline-toclink-visited: #054572;
+
+	--text-heading: #005a9c;
+	--text-hr: var(--text);
+
+	--border-algo: #def;
+
+	--text-correction: var(--text);
+	--bg-correction: rgba(255, 255, 0, 0.5);
+	--border-correction: yellow;
+	--text-addition: var(--text);
+	--bg-addition: rgba(0, 255, 0, 0.5);
+	--border-addition: green;
+
+	--text-del: red;
+	--bg-del: transparent;
+	--text-ins: #080;
+	--bg-ins: transparent;
+
+	--text-a-normal: #034575;
+	--underline-a-normal: #707070;
+	--text-a-visited: purple;
+	--underline-a-visited: #bbb;
+	--bg-a-hover: rgba(75%, 75%, 75%, .25);
+	--text-a-active: #c00;
+	--underline-a-active: #c00;
+
+	--border-blockquote: silver;
+	--bg-blockquote: var(--bg);
+	--text-blockquote: var(--text);
+
+	--border-issue: #e05252;
+	--bg-issue: #fbe9e9;
+	--text-issue: var(--text);
+	--text-issueheading: #831616;
+
+	--border-example: #e0cb52;
+	--bg-example: #fcfaee;
+	--text-example: var(--text);
+	--text-exampleheading: #574b0f;
+
+	--border-note: #52e052;
+	--bg-note: #e9fbe9;
+	--text-note: var(--text);
+	--text-noteheading: hsl(120, 70%, 30%);
+	--underline-notesummary: silver;
+
+	--border-advisement: orange;
+	--bg-advisement: #fec;
+	--text-advisement: var(--text);
+	--text-advisementheading: #b35f00;
+
+	--border-warning: red;
+	--bg-warning: hsla(40,100%,50%,0.95);
+	--text-warning: var(--text);
+
+	--border-def: #8ccbf2;
+	--bg-def: #def;
+	--text-def: var(--text);
+	--border-defrow: #bbd7e9;
+
+	--border-datacell: silver;
+
+	--text-indexinfo: #707070;
+
+	--text-propindex-hover: black;
+	--bg-propindex-hover: #f7f8f9;
+
+	--bg-outdatedspec: rgba(0, 0, 0, .5);
+	--text-outdatedspec: black;
+	--bg-outdated: maroon;
+	--text-outdated: white;
+	--shadow-outdated: red;
+
+	--bg-editedrec: darkorange;
+}
+
 /******************************************************************************/
 /*                                   Body                                     */
 /******************************************************************************/
@@ -87,7 +192,9 @@
 
 		/* Colors */
 		color: black;
+		color: var(--text);
 		background: white top left fixed no-repeat;
+		background-color: var(--bg);
 		background-size: 25px auto;
 	}
 
@@ -124,10 +231,11 @@
 	.head img[src*="logos/W3C"] {
 		display: block;
 		border: solid #1a5e9a;
+		border: solid var(--bg-logo);
 		border-width: .65rem .7rem .6rem;
 		border-radius: .4rem;
 		background: #1a5e9a;
-		color: white;
+		background: var(--bg-logo);
 		font-weight: bold;
 	}
 
@@ -138,7 +246,9 @@
 
 	.head a:active > img[src*="logos/W3C"] {
 		background: #c00;
+		background: var(--bg-logo-active);
 		border-color: #c00;
+		border-color: var(--bg-logo-active);
 	}
 
 	/* see also additional rules in Link Styling section */
@@ -165,7 +275,6 @@
 			border-top-right-radius: 2rem;
 			box-shadow: 0 0 2px;
 			font-size: 1.5em;
-			color: black;
 		}
 		#toc-nav > a {
 			display: block;
@@ -178,19 +287,29 @@
 			box-shadow: 0 0 2px;
 			border: none;
 			border-top-right-radius: 1.33em;
+
+			color: #707070;
+			color: var(--text-tocnav-normal);
 			background: white;
+			background: var(--bg-tocnav-normal);
 		}
+		#toc-nav > a:hover,
+		#toc-nav > a:focus {
+			color: black;
+			color: var(--text-tocnav-hover);
+			background: #f8f8f8;
+			background: var(--bg-tocnav-hover);
+		}
+		#toc-nav > a:active {
+			color: #C00;
+			color: var(--text-tocnav-active);
+			background: white;
+			background: var(--bg-tocnav-active);
+		}
+
 		#toc-nav > #toc-jump {
 			padding-bottom: 2em;
 			margin-bottom: -1.9em;
-		}
-
-		#toc-nav > a:hover,
-		#toc-nav > a:focus {
-			background: #f8f8f8;
-		}
-		#toc-nav > a:not(:hover):not(:focus) {
-			color: #707070;
 		}
 
 		/* statusbar gets in the way on keyboard focus; remove once browsers fix */
@@ -204,10 +323,6 @@
 		}
 		#toc-nav > a > span + span {
 			padding-right: 0.2em;
-		}
-
-		#toc-nav :active {
-			color: #C00;
 		}
 	}
 
@@ -226,10 +341,14 @@
 			padding: 0 1em;
 			padding-left: 42px;
 			padding-left: calc(1em + 26px);
+			color: black;
+			color: var(--text-tocsidebar);
 			background: inherit;
 			background-color: #f7f8f9;
+			background-color: var(--bg-tocsidebar);
 			z-index: 1;
 			box-shadow: -.1em 0 .25em rgba(0,0,0,.1) inset;
+			box-shadow: -.1em 0 .25em var(--shadow-tocsidebar) inset;
 		}
 		body.toc-sidebar #toc h2 {
 			margin-top: .8rem;
@@ -239,6 +358,7 @@
 			font-weight: bold;
 			color: gray;
 			color: hsla(203,20%,40%,.7);
+			color: var(--text-tocsidebar-heading);
 		}
 		body.toc-sidebar #toc-jump:not(:focus) {
 			width: 0;
@@ -266,10 +386,14 @@
 			padding: 0 1em;
 			padding-left: 42px;
 			padding-left: calc(1em + 26px);
+			color: black;
+			color: var(--text-tocsidebar);
 			background: inherit;
 			background-color: #f7f8f9;
+			background-color: var(--bg-tocsidebar);
 			z-index: 1;
 			box-shadow: -.1em 0 .25em rgba(0,0,0,.1) inset;
+			box-shadow: -.1em 0 .25em var(--shadow-tocsidebar) inset;
 		}
 		body:not(.toc-inline) #toc h2 {
 			margin-top: .8rem;
@@ -279,6 +403,7 @@
 			font-weight: bold;
 			color: gray;
 			color: hsla(203,20%,40%,.7);
+			color: var(--text-tocsidebar-heading);
 		}
 
 		body:not(.toc-inline) {
@@ -321,7 +446,7 @@
 
 	h1, h2, h3 {
 		color: #005A9C;
-		background: transparent;
+		color: var(--text-heading);
 	}
 
 	h1 { font-size: 170%; }
@@ -357,6 +482,8 @@
 		text-align: center;
 		margin: 1em auto;
 		height: auto;
+		color: black;
+		color: var(--text-hr);
 		border: transparent solid 0;
 		background: transparent;
 	}
@@ -399,6 +526,7 @@
 	ol.algorithm ol:not(.algorithm),
 	.algorithm > ol ol:not(.algorithm) {
 	 border-left: 0.5em solid #DEF;
+	 border-left: 0.5em solid var(--border-algo);
 	}
 
 	/* Style for switch/case <dl>s */
@@ -427,16 +555,24 @@
 	 line-height: 0.5em;
 	}
 	.correction {
+		color: black;
+		color: var(--text-correction);
 		background: rgba(255, 255, 0, 0.5);
+		background: var(--bg-correction);
 		border-left: 10px solid yellow;
+		border-left: 10px solid var(--border-correction);
 		padding-left: 10px;
 	}
 	p.correction:before {
 		content: "PROPOSED CORRECTION: ";
 	}
 	.addition {
+		color: black;
+		color: var(--text-addition);
 		background: rgba(0, 255, 0, 50%);
+		background: var(--bg-addition);
 		border-left: 10px solid green;
+		border-left: 10px solid var(--border-addition);
 		padding-left: 10px;
 	}
 	p.addition:before {
@@ -466,8 +602,20 @@
 
 /** Change Marking ************************************************************/
 
-	del { color: red;  text-decoration: line-through; }
-	ins { color: #080; text-decoration: underline;    }
+	del {
+		color: red;
+		color: var(--text-del);
+		background: transparent;
+		background: var(--bg-del);
+		text-decoration: line-through;
+	}
+	ins {
+		color: #080;
+		color: var(--text-ins);
+		background: transparent;
+		background: var(--bg-ins);
+		text-decoration: underline;
+	}
 
 /** Miscellaneous improvements to inline formatting ***************************/
 
@@ -518,8 +666,10 @@
 	/* We hyperlink a lot, so make it less intrusive */
 	a[href] {
 		color: #034575;
+		color: var(--text-a-normal);
 		text-decoration: none;
 		border-bottom: 1px solid #707070;
+		border-bottom: 1px solid var(--underline-a-normal);
 		/* Need a bit of extending for it to look okay */
 		padding: 0 1px 0;
 		margin: 0 -1px 0;
@@ -533,12 +683,15 @@
 	a[href]:hover {
 		background: #f8f8f8;
 		background: rgba(75%, 75%, 75%, .25);
+		background: var(--bg-a-hover);
 		border-bottom-width: 3px;
 		margin-bottom: -2px;
 	}
 	a[href]:active {
 		color: #C00;
+		color: var(--text-a-active);
 		border-color: #C00;
+		border-color: var(--underline-a-active);
 	}
 
 	/* Backout above styling for W3C logo */
@@ -632,24 +785,40 @@
 		margin-bottom: 0;
 	}
 
+
+	.issue::before, .issue > .marker,
+	.example::before, .example > .marker,
+	.note::before, .note > .marker {
+		text-transform: uppercase;
+		display: block;
+	}
+
 /** Blockquotes ***************************************************************/
 
 	blockquote {
 		border-color: silver;
+		border-color: var(--border-blockquote);
+		background: white;
+		background: var(--bg-blockquote);
+		color: black;
+		color: var(--text-blockquote);
 	}
 
 /** Open issue ****************************************************************/
 
 	.issue {
 		border-color: #E05252;
+		border-color: var(--border-issue);
 		background: #FBE9E9;
+		background: var(--bg-issue);
+		color: black;
+		color: var(--text-issue);
 		counter-increment: issue;
 		overflow: auto;
 	}
 	.issue::before, .issue > .marker {
 		color: #831616;
-		padding-right: 1em;
-		text-transform: uppercase;
+		color: var(--text-issueheading);
 	}
 	/* Add .issue::before { content: "Issue " counter(issue) " "; } for autogen numbers,
 	   or use class="marker" to mark up the issue number in source. */
@@ -658,16 +827,18 @@
 
 	.example {
 		border-color: #E0CB52;
+		border-color: var(--border-example);
 		background: #FCFAEE;
+		background: var(--bg-example);
+		color: black;
+		color: var(--text-example);
 		counter-increment: example;
 		overflow: auto;
 		clear: both;
 	}
 	.example::before, .example > .marker {
-		text-transform: uppercase;
 		color: #574b0f;
-		min-width: 7.5em;
-		display: block;
+		color: var(--text-exampleheading);
 	}
 	/* Add .example::before { content: "Example " counter(example) " "; } for autogen numbers,
 	   or use class="marker" to mark up the example number in source. */
@@ -676,25 +847,25 @@
 
 	.note {
 		border-color: #52E052;
+		border-color: var(--border-note);
 		background: #E9FBE9;
+		background: var(--bg-note);
+		color: black;
+		color: var(--text-note);
 		overflow: auto;
 	}
 
 	.note::before, .note > .marker,
-	details.note > summary::before,
-	details.note > summary > .marker {
-		text-transform: uppercase;
-		display: block;
+	details.note > summary {
 		color: hsl(120, 70%, 30%);
+		color: var(--text-noteheading);
 	}
 	/* Add .note::before { content: "Note "; } for autogen label,
 	   or use class="marker" to mark up the label in source. */
 
-	details.note > summary {
-		color: hsl(120, 70%, 30%);
-	}
 	details.note[open] > summary {
 		border-bottom: 1px silver solid;
+		border-bottom: 1px var(--underline-notesummary) solid;
 	}
 
 /** Advisement Box ************************************************************/
@@ -702,15 +873,20 @@
 
 	.advisement {
 		border-color: orange;
+		border-color: var(--border-advisement);
 		border-style: none solid;
 		background: #FFEECC;
+		background: var(--bg-advisement);
+		color: black;
+		color: var(--text-advisement);
 	}
 	strong.advisement {
 		display: block;
 		text-align: center;
 	}
-	.advisement > .marker {
+	.advisement::before, .advisement > .marker {
 		color: #B35F00;
+		color: var(--text-advisementheading);
 	}
 
 /** Spec Obsoletion Notice ****************************************************/
@@ -727,9 +903,12 @@
 	details.annoying-warning:not([open]) > summary,
 	details.annoying-warning[open] {
 		background: hsla(40,100%,50%,0.95);
+		background: var(--bg-warning);
 		color: black;
+		color: var(--text-warning);
 		padding: .75em 1em;
 		border: red;
+		border: var(--border-warning);
 		border-style: solid none;
 		box-shadow: 0 2px 8px black;
 		text-align: center;
@@ -757,8 +936,12 @@
 	.def {
 		padding: .5em 1em;
 		background: #DEF;
+		background: var(--bg-def);
 		margin: 1.2em 0;
 		border-left: 0.5em solid #8CCBF2;
+		border-left: 0.5em solid var(--border-def);
+		color: black;
+		color: var(--text-def);
 	}
 
 /******************************************************************************/
@@ -783,6 +966,7 @@
 		padding: 0.5em;
 		vertical-align: baseline;
 		border-bottom: 1px solid #bbd7e9;
+		border-bottom: 1px solid var(--rowborder-def);
 	}
 
 	table.def > tbody > tr:last-child th,
@@ -803,10 +987,10 @@
 	}
 
 	/* A footnote at the bottom of a def table */
-	table.def           td.footnote {
+	table.def td.footnote {
 		padding-top: 0.6em;
 	}
-	table.def           td.footnote::before {
+	table.def td.footnote::before {
 		content: " ";
 		display: block;
 		height: 0.6em;
@@ -851,6 +1035,7 @@
 		padding: 0.5em 1em;
 		border-width: 1px;
 		border-color: silver;
+		border-color: var(--border-datacell);
 		border-top-style: solid;
 	}
 
@@ -875,6 +1060,7 @@
 	table.index tbody th:first-child  {
 		border-right: 2px solid;
 		border-top: 1px solid silver;
+		border-top: 1px solid var(--border-datacell);
 		padding-right: 1em;
 	}
 
@@ -886,6 +1072,7 @@
 	table.complex.data th,
 	table.complex.data td {
 		border: 1px solid silver;
+		border: 1px solid var(--border-datacell);
 		text-align: center;
 	}
 
@@ -950,10 +1137,15 @@ Possible extra rowspan handling
 		display: block;
 		/* Reverse color scheme */
 		color: black;
+		color: var(--text-toclink);
 		border-color: #3980B5;
+		border-color: var(--underline-toclink);
 	}
 	.toc a:visited {
+		color: black;
+		color: var(--text-toclink-visited);
 		border-color: #054572;
+		border-color: var(--underline-toclink-visited);
 	}
 	.toc a:not(:focus):not(:hover) {
 		/* Allow colors to cascade through from link styling */
@@ -1049,6 +1241,7 @@ Possible extra rowspan handling
 		ul.index li a:hover + span,
 		ul.index li a:focus + span {
 			color: #707070;
+			color: var(--text-indexinfo);
 		}
 	}
 
@@ -1070,7 +1263,10 @@ Possible extra rowspan handling
 
 	table.index tr:hover td:not([rowspan]),
 	table.index tr:hover th:not([rowspan]) {
+		color: black;
+		color: var(--text-propindex-hover);
 		background: #f7f8f9;
+		background: var(--bg-propindex-hover);
 	}
 
 	/* The link in the first column in the property table (formerly a TD) */
@@ -1080,16 +1276,11 @@ Possible extra rowspan handling
 
 /** Outdated warning **********************************************************/
 
-a#outdated-note {
-	color: white;
-}
-
-a#outdated-note:hover {
-	background: transparent;
-}
-
 .outdated-spec {
+	color: black;
+	color: var(--text-outdatedspec);
 	background-color: rgba(0,0,0,0.5);
+	background-color: var(--bg-outdatedspec);
 }
 
 .outdated-warning {
@@ -1100,16 +1291,28 @@ a#outdated-note:hover {
 	margin: 0 auto;
 	width: 50%;
 	background: maroon;
+	background: var(--bg-outdated);
 	color: white;
+	color: var(--text-outdated);
 	border-radius: 1em;
 	box-shadow: 0 0 1em red;
+	box-shadow: 0 0 1em var(--shadow-outdated);
 	padding: 2em;
 	text-align: center;
 	z-index: 2;
 }
 
+.outdated-warning a#outdated-note {
+	color: white;
+	color: var(--text-outdated);
+}
+.outdated-warning a#outdated-note:hover {
+	background: transparent;
+}
+
 .edited-rec-warning {
 	background: darkorange;
+	background: var(--bg-editedrec);
 	box-shadow: 0 0 1em;
 }
 
@@ -1122,6 +1325,7 @@ a#outdated-note:hover {
 	padding: 0.25em 0.5em;
 	background: transparent;
 	color: white;
+	color: var(--text-outdated);
 	font:1em sans-serif;
 	text-align:center;
 }
@@ -1192,7 +1396,7 @@ a#outdated-note:hover {
 		   1. When item < content column, centers item in column.
 		   2. When content < item < available, left-aligns.
 		   3. When item > available, fills available and is scrollable.
-		*/ 
+		*/
 		display: grid;
 		grid-template-columns: minmax(0, 50em);
 	}

--- a/src/base.css
+++ b/src/base.css
@@ -679,11 +679,6 @@
 		border-style: none;
 	}
 
-	img, svg {
-		/* This isn't color-scheme aware, on purpose. */
-		background: white;
-	}
-
 	/* For autogen numbers, add
 	   .caption::before, figcaption::before { content: "Figure " counter(figure) ". "; }
 	*/

--- a/src/base.css
+++ b/src/base.css
@@ -763,10 +763,12 @@
 	.note::before, .note > .marker,
 	details.note > summary > .marker {
 		text-transform: uppercase;
+		padding-right: 1em;
 	}
 
 	.example::before, .example > .marker {
 		display: block;
+		padding-right: 0em;
 	}
 
 /** Blockquotes ***************************************************************/

--- a/src/base.css
+++ b/src/base.css
@@ -1282,8 +1282,6 @@ Possible extra rowspan handling
 
 .outdated-warning a#outdated-note {
 	color: currentcolor;
-}
-.outdated-warning a#outdated-note:hover {
 	background: transparent;
 }
 

--- a/src/base.css
+++ b/src/base.css
@@ -76,6 +76,7 @@
 
 	--logo-bg: #1a5e9a;
 	--logo-active-bg: #c00;
+	--logo-text: white;
 
 	--tocnav-normal-text: #707070;
 	--tocnav-normal-bg: var(--bg);
@@ -230,6 +231,8 @@
 		border-radius: .4rem;
 		background: #1a5e9a;
 		background: var(--logo-bg);
+		color: white;
+		color: var(--logo-text);
 		font-weight: bold;
 	}
 

--- a/src/base.css
+++ b/src/base.css
@@ -107,7 +107,7 @@
 
 	--a-normal-text: #034575;
 	--a-normal-underline: #707070;
-	--a-visited-text: purple;
+	--a-visited-text: var(--a-normal-text);
 	--a-visited-underline: #bbb;
 	--a-hover-bg: rgba(75%, 75%, 75%, .25);
 	--a-active-text: #c00;
@@ -641,7 +641,10 @@
 		margin: 0 -1px 0;
 	}
 	a:visited {
+		color: #034575;
+		color: var(--a-visited-text);
 		border-bottom-color: #BBB;
+		border-bottom-color: var(--a-visited-underline);
 	}
 
 	/* Use distinguishing colors when user is interacting with the link */

--- a/src/base.css
+++ b/src/base.css
@@ -69,97 +69,98 @@
 /*                                  Colors                                    */
 /******************************************************************************/
 
-/* Any --text-* not paired with a --bg-* is assumed to have a transparent bg */
-:root {
+/* Any --* not paired with a --bg-* is assumed to have a transparent bg */
+-text:root {
 	--text: black;
 	--bg: white;
 
-	--bg-logo: #1a5e9a;
-	--bg-logo-active: #c00;
+	--logo-bg: #1a5e9a;
+	--logo-active-bg: #c00;
 
-	--text-tocnav-normal: #707070;
-	--bg-tocnav-normal: var(--bg);
-	--text-tocnav-hover: var(--text-tocnav-normal);
-	--bg-tocnav-hover: #f8f8f8;
-	--text-tocnav-active: #c00;
-	--bg-tocnav-active: var(--bg-tocnav-normal);
+	--tocnav-normal-text: #707070;
+	--tocnav-normal-bg: var(--bg);
+	--tocnav-hover-text: var(--tocnav-normal-text);
+	--tocnav-hover-bg: #f8f8f8;
+	--tocnav-active-text: #c00;
+	--tocnav-active-bg: var(--tocnav-normal-bg);
 
-	--text-tocsidebar: var(--text);
-	--bg-tocsidebar: #f7f8f9;
-	--shadow-tocsidebar: rgba(0,0,0,.1);
-	--text-tocsidebar-heading: hsla(203,20%,40%,.7);
+	--tocsidebar-text: var(--text);
+	--tocsidebar-bg: #f7f8f9;
+	--tocsidebar-shadow: rgba(0,0,0,.1);
+	--tocsidebar-heading-text: hsla(203,20%,40%,.7);
 
-	--text-toclink: black;
-	--underline-toclink: #3980b5;
-	--text-toclink-visited: var(--text-toclink);
-	--underline-toclink-visited: #054572;
+	--toclink-text: black;
+	--toclink-underline: #3980b5;
+	--toclink-visited-text: var(--toclink-text);
+	--toclink-visited-underline: #054572;
 
-	--text-heading: #005a9c;
-	--text-hr: var(--text);
+	--heading-text: #005a9c;
 
-	--border-algo: #def;
+	--hr-text: var(--text);
 
-	--text-del: red;
-	--bg-del: transparent;
-	--text-ins: #080;
-	--bg-ins: transparent;
+	--algo-border: #def;
 
-	--text-a-normal: #034575;
-	--underline-a-normal: #707070;
-	--text-a-visited: purple;
-	--underline-a-visited: #bbb;
-	--bg-a-hover: rgba(75%, 75%, 75%, .25);
-	--text-a-active: #c00;
-	--underline-a-active: #c00;
+	--del-text: red;
+	--del-bg: transparent;
+	--ins-text: #080;
+	--ins-bg: transparent;
 
-	--border-blockquote: silver;
-	--bg-blockquote: var(--bg);
-	--text-blockquote: var(--text);
+	--a-normal-text: #034575;
+	--a-normal-underline: #707070;
+	--a-visited-text: purple;
+	--a-visited-underline: #bbb;
+	--a-hover-bg: rgba(75%, 75%, 75%, .25);
+	--a-active-text: #c00;
+	--a-active-underline: #c00;
 
-	--border-issue: #e05252;
-	--bg-issue: #fbe9e9;
-	--text-issue: var(--text);
-	--text-issueheading: #831616;
+	--blockquote-border: silver;
+	--blockquote-bg: var(--bg);
+	--blockquote-text: var(--text);
 
-	--border-example: #e0cb52;
-	--bg-example: #fcfaee;
-	--text-example: var(--text);
-	--text-exampleheading: #574b0f;
+	--issue-border: #e05252;
+	--issue-bg: #fbe9e9;
+	--issue-text: var(--text);
+	--issueheading-text: #831616;
 
-	--border-note: #52e052;
-	--bg-note: #e9fbe9;
-	--text-note: var(--text);
-	--text-noteheading: hsl(120, 70%, 30%);
-	--underline-notesummary: silver;
+	--example-border: #e0cb52;
+	--example-bg: #fcfaee;
+	--example-text: var(--text);
+	--exampleheading-text: #574b0f;
 
-	--border-advisement: orange;
-	--bg-advisement: #fec;
-	--text-advisement: var(--text);
-	--text-advisementheading: #b35f00;
+	--note-border: #52e052;
+	--note-bg: #e9fbe9;
+	--note-text: var(--text);
+	--noteheading-text: hsl(120, 70%, 30%);
+	--notesummary-underline: silver;
 
-	--border-warning: red;
-	--bg-warning: hsla(40,100%,50%,0.95);
-	--text-warning: var(--text);
+	--advisement-border: orange;
+	--advisement-bg: #fec;
+	--advisement-text: var(--text);
+	--advisementheading-text: #b35f00;
 
-	--border-def: #8ccbf2;
-	--bg-def: #def;
-	--text-def: var(--text);
-	--border-defrow: #bbd7e9;
+	--warning-border: red;
+	--warning-bg: hsla(40,100%,50%,0.95);
+	--warning-text: var(--text);
 
-	--border-datacell: silver;
+	--def-border: #8ccbf2;
+	--def-bg: #def;
+	--def-text: var(--text);
+	--defrow-border: #bbd7e9;
 
-	--text-indexinfo: #707070;
+	--datacell-border: silver;
 
-	--text-propindex-hover: black;
-	--bg-propindex-hover: #f7f8f9;
+	--indexinfo-text: #707070;
 
-	--bg-outdatedspec: rgba(0, 0, 0, .5);
-	--text-outdatedspec: black;
-	--bg-outdated: maroon;
-	--text-outdated: white;
-	--shadow-outdated: red;
+	--propindex-hover-text: black;
+	--propindex-hover-bg: #f7f8f9;
 
-	--bg-editedrec: darkorange;
+	--outdatedspec-bg: rgba(0, 0, 0, .5);
+	--outdatedspec-text: black;
+	--outdated-bg: maroon;
+	--outdated-text: white;
+	--outdated-shadow: red;
+
+	--editedrec-bg: darkorange;
 }
 
 /******************************************************************************/
@@ -224,11 +225,11 @@
 	.head img[src*="logos/W3C"] {
 		display: block;
 		border: solid #1a5e9a;
-		border: solid var(--bg-logo);
+		border: solid var(--logo-bg);
 		border-width: .65rem .7rem .6rem;
 		border-radius: .4rem;
 		background: #1a5e9a;
-		background: var(--bg-logo);
+		background: var(--logo-bg);
 		font-weight: bold;
 	}
 
@@ -239,9 +240,9 @@
 
 	.head a:active > img[src*="logos/W3C"] {
 		background: #c00;
-		background: var(--bg-logo-active);
+		background: var(--logo-active-bg);
 		border-color: #c00;
-		border-color: var(--bg-logo-active);
+		border-color: var(--logo-active-bg);
 	}
 
 	/* see also additional rules in Link Styling section */
@@ -282,22 +283,22 @@
 			border-top-right-radius: 1.33em;
 
 			color: #707070;
-			color: var(--text-tocnav-normal);
+			color: var(--tocnav-normal-text);
 			background: white;
-			background: var(--bg-tocnav-normal);
+			background: var(--tocnav-normal-bg);
 		}
 		#toc-nav > a:hover,
 		#toc-nav > a:focus {
 			color: black;
-			color: var(--text-tocnav-hover);
+			color: var(--tocnav-hover-text);
 			background: #f8f8f8;
-			background: var(--bg-tocnav-hover);
+			background: var(--tocnav-hover-bg);
 		}
 		#toc-nav > a:active {
 			color: #C00;
-			color: var(--text-tocnav-active);
+			color: var(--tocnav-active-text);
 			background: white;
-			background: var(--bg-tocnav-active);
+			background: var(--tocnav-active-bg);
 		}
 
 		#toc-nav > #toc-jump {
@@ -335,13 +336,13 @@
 			padding-left: 42px;
 			padding-left: calc(1em + 26px);
 			color: black;
-			color: var(--text-tocsidebar);
+			color: var(--tocsidebar-text);
 			background: inherit;
 			background-color: #f7f8f9;
-			background-color: var(--bg-tocsidebar);
+			background-color: var(--tocsidebar-bg);
 			z-index: 1;
 			box-shadow: -.1em 0 .25em rgba(0,0,0,.1) inset;
-			box-shadow: -.1em 0 .25em var(--shadow-tocsidebar) inset;
+			box-shadow: -.1em 0 .25em var(--tocsidebar-shadow) inset;
 		}
 		body.toc-sidebar #toc h2 {
 			margin-top: .8rem;
@@ -351,7 +352,7 @@
 			font-weight: bold;
 			color: gray;
 			color: hsla(203,20%,40%,.7);
-			color: var(--text-tocsidebar-heading);
+			color: var(--tocsidebar-heading-text);
 		}
 		body.toc-sidebar #toc-jump:not(:focus) {
 			width: 0;
@@ -380,13 +381,13 @@
 			padding-left: 42px;
 			padding-left: calc(1em + 26px);
 			color: black;
-			color: var(--text-tocsidebar);
+			color: var(--tocsidebar-text);
 			background: inherit;
 			background-color: #f7f8f9;
-			background-color: var(--bg-tocsidebar);
+			background-color: var(--tocsidebar-bg);
 			z-index: 1;
 			box-shadow: -.1em 0 .25em rgba(0,0,0,.1) inset;
-			box-shadow: -.1em 0 .25em var(--shadow-tocsidebar) inset;
+			box-shadow: -.1em 0 .25em var(--tocsidebar-shadow) inset;
 		}
 		body:not(.toc-inline) #toc h2 {
 			margin-top: .8rem;
@@ -396,7 +397,7 @@
 			font-weight: bold;
 			color: gray;
 			color: hsla(203,20%,40%,.7);
-			color: var(--text-tocsidebar-heading);
+			color: var(--tocsidebar-heading-text);
 		}
 
 		body:not(.toc-inline) {
@@ -439,7 +440,7 @@
 
 	h1, h2, h3 {
 		color: #005A9C;
-		color: var(--text-heading);
+		color: var(--heading-text);
 	}
 
 	h1 { font-size: 170%; }
@@ -472,7 +473,7 @@
 		margin: 1em auto;
 		height: auto;
 		color: black;
-		color: var(--text-hr);
+		color: var(--hr-text);
 		border: transparent solid 0;
 		background: transparent;
 	}
@@ -515,7 +516,7 @@
 	ol.algorithm ol:not(.algorithm),
 	.algorithm > ol ol:not(.algorithm) {
 	 border-left: 0.5em solid #DEF;
-	 border-left: 0.5em solid var(--border-algo);
+	 border-left: 0.5em solid var(--algo-border);
 	}
 
 	/* Style for switch/case <dl>s */
@@ -569,16 +570,16 @@
 
 	del {
 		color: red;
-		color: var(--text-del);
+		color: var(--del-text);
 		background: transparent;
-		background: var(--bg-del);
+		background: var(--del-bg);
 		text-decoration: line-through;
 	}
 	ins {
 		color: #080;
-		color: var(--text-ins);
+		color: var(--ins-text);
 		background: transparent;
-		background: var(--bg-ins);
+		background: var(--ins-bg);
 		text-decoration: underline;
 	}
 
@@ -631,10 +632,10 @@
 	/* We hyperlink a lot, so make it less intrusive */
 	a[href] {
 		color: #034575;
-		color: var(--text-a-normal);
+		color: var(--a-normal-text);
 		text-decoration: none;
 		border-bottom: 1px solid #707070;
-		border-bottom: 1px solid var(--underline-a-normal);
+		border-bottom: 1px solid var(--a-normal-underline);
 		/* Need a bit of extending for it to look okay */
 		padding: 0 1px 0;
 		margin: 0 -1px 0;
@@ -648,15 +649,15 @@
 	a[href]:hover {
 		background: #f8f8f8;
 		background: rgba(75%, 75%, 75%, .25);
-		background: var(--bg-a-hover);
+		background: var(--a-hover-bg);
 		border-bottom-width: 3px;
 		margin-bottom: -2px;
 	}
 	a[href]:active {
 		color: #C00;
-		color: var(--text-a-active);
+		color: var(--a-active-text);
 		border-color: #C00;
-		border-color: var(--underline-a-active);
+		border-color: var(--a-active-underline);
 	}
 
 	/* Backout above styling for W3C logo */
@@ -767,28 +768,28 @@
 
 	blockquote {
 		border-color: silver;
-		border-color: var(--border-blockquote);
+		border-color: var(--blockquote-border);
 		background: white;
-		background: var(--bg-blockquote);
+		background: var(--blockquote-bg);
 		color: black;
-		color: var(--text-blockquote);
+		color: var(--blockquote-text);
 	}
 
 /** Open issue ****************************************************************/
 
 	.issue {
 		border-color: #E05252;
-		border-color: var(--border-issue);
+		border-color: var(--issue-border);
 		background: #FBE9E9;
-		background: var(--bg-issue);
+		background: var(--issue-bg);
 		color: black;
-		color: var(--text-issue);
+		color: var(--issue-text);
 		counter-increment: issue;
 		overflow: auto;
 	}
 	.issue::before, .issue > .marker {
 		color: #831616;
-		color: var(--text-issueheading);
+		color: var(--issueheading-text);
 	}
 	/* Add .issue::before { content: "Issue " counter(issue) " "; } for autogen numbers,
 	   or use class="marker" to mark up the issue number in source. */
@@ -797,18 +798,18 @@
 
 	.example {
 		border-color: #E0CB52;
-		border-color: var(--border-example);
+		border-color: var(--example-border);
 		background: #FCFAEE;
-		background: var(--bg-example);
+		background: var(--example-bg);
 		color: black;
-		color: var(--text-example);
+		color: var(--example-text);
 		counter-increment: example;
 		overflow: auto;
 		clear: both;
 	}
 	.example::before, .example > .marker {
 		color: #574b0f;
-		color: var(--text-exampleheading);
+		color: var(--exampleheading-text);
 	}
 	/* Add .example::before { content: "Example " counter(example) " "; } for autogen numbers,
 	   or use class="marker" to mark up the example number in source. */
@@ -817,25 +818,25 @@
 
 	.note {
 		border-color: #52E052;
-		border-color: var(--border-note);
+		border-color: var(--note-border);
 		background: #E9FBE9;
-		background: var(--bg-note);
+		background: var(--note-bg);
 		color: black;
-		color: var(--text-note);
+		color: var(--note-text);
 		overflow: auto;
 	}
 
 	.note::before, .note > .marker,
 	details.note > summary {
 		color: hsl(120, 70%, 30%);
-		color: var(--text-noteheading);
+		color: var(--noteheading-text);
 	}
 	/* Add .note::before { content: "Note "; } for autogen label,
 	   or use class="marker" to mark up the label in source. */
 
 	details.note[open] > summary {
 		border-bottom: 1px silver solid;
-		border-bottom: 1px var(--underline-notesummary) solid;
+		border-bottom: 1px var(--notesummary-underline) solid;
 	}
 
 /** Advisement Box ************************************************************/
@@ -843,12 +844,12 @@
 
 	.advisement {
 		border-color: orange;
-		border-color: var(--border-advisement);
+		border-color: var(--advisement-border);
 		border-style: none solid;
 		background: #FFEECC;
-		background: var(--bg-advisement);
+		background: var(--advisement-bg);
 		color: black;
-		color: var(--text-advisement);
+		color: var(--advisement-text);
 	}
 	strong.advisement {
 		display: block;
@@ -856,7 +857,7 @@
 	}
 	.advisement::before, .advisement > .marker {
 		color: #B35F00;
-		color: var(--text-advisementheading);
+		color: var(--advisementheading-text);
 	}
 
 /** Spec Obsoletion Notice ****************************************************/
@@ -873,12 +874,12 @@
 	details.annoying-warning:not([open]) > summary,
 	details.annoying-warning[open] {
 		background: hsla(40,100%,50%,0.95);
-		background: var(--bg-warning);
+		background: var(--warning-bg);
 		color: black;
-		color: var(--text-warning);
+		color: var(--warning-text);
 		padding: .75em 1em;
 		border: red;
-		border: var(--border-warning);
+		border: var(--warning-border);
 		border-style: solid none;
 		box-shadow: 0 2px 8px black;
 		text-align: center;
@@ -906,12 +907,12 @@
 	.def {
 		padding: .5em 1em;
 		background: #DEF;
-		background: var(--bg-def);
+		background: var(--def-bg);
 		margin: 1.2em 0;
 		border-left: 0.5em solid #8CCBF2;
-		border-left: 0.5em solid var(--border-def);
+		border-left: 0.5em solid var(--def-border);
 		color: black;
-		color: var(--text-def);
+		color: var(--def-text);
 	}
 
 /******************************************************************************/
@@ -936,7 +937,7 @@
 		padding: 0.5em;
 		vertical-align: baseline;
 		border-bottom: 1px solid #bbd7e9;
-		border-bottom: 1px solid var(--rowborder-def);
+		border-bottom: 1px solid var(--def-rowborder);
 	}
 
 	table.def > tbody > tr:last-child th,
@@ -1005,7 +1006,7 @@
 		padding: 0.5em 1em;
 		border-width: 1px;
 		border-color: silver;
-		border-color: var(--border-datacell);
+		border-color: var(--datacell-border);
 		border-top-style: solid;
 	}
 
@@ -1030,7 +1031,7 @@
 	table.index tbody th:first-child  {
 		border-right: 2px solid;
 		border-top: 1px solid silver;
-		border-top: 1px solid var(--border-datacell);
+		border-top: 1px solid var(--datacell-border);
 		padding-right: 1em;
 	}
 
@@ -1042,7 +1043,7 @@
 	table.complex.data th,
 	table.complex.data td {
 		border: 1px solid silver;
-		border: 1px solid var(--border-datacell);
+		border: 1px solid var(--datacell-border);
 		text-align: center;
 	}
 
@@ -1107,15 +1108,15 @@ Possible extra rowspan handling
 		display: block;
 		/* Reverse color scheme */
 		color: black;
-		color: var(--text-toclink);
+		color: var(--toclink-text);
 		border-color: #3980B5;
-		border-color: var(--underline-toclink);
+		border-color: var(--toclink-underline);
 	}
 	.toc a:visited {
 		color: black;
-		color: var(--text-toclink-visited);
+		color: var(--toclink-visited-text);
 		border-color: #054572;
-		border-color: var(--underline-toclink-visited);
+		border-color: var(--toclink-visited-underline);
 	}
 	.toc a:not(:focus):not(:hover) {
 		/* Allow colors to cascade through from link styling */
@@ -1211,7 +1212,7 @@ Possible extra rowspan handling
 		ul.index li a:hover + span,
 		ul.index li a:focus + span {
 			color: #707070;
-			color: var(--text-indexinfo);
+			color: var(--indexinfo-text);
 		}
 	}
 
@@ -1234,9 +1235,9 @@ Possible extra rowspan handling
 	table.index tr:hover td:not([rowspan]),
 	table.index tr:hover th:not([rowspan]) {
 		color: black;
-		color: var(--text-propindex-hover);
+		color: var(--propindex-hover-text);
 		background: #f7f8f9;
-		background: var(--bg-propindex-hover);
+		background: var(--propindex-hover-bg);
 	}
 
 	/* The link in the first column in the property table (formerly a TD) */
@@ -1248,9 +1249,9 @@ Possible extra rowspan handling
 
 .outdated-spec {
 	color: black;
-	color: var(--text-outdatedspec);
+	color: var(--outdatedspec-text);
 	background-color: rgba(0,0,0,0.5);
-	background-color: var(--bg-outdatedspec);
+	background-color: var(--outdatedspec-bg);
 }
 
 .outdated-warning {
@@ -1261,12 +1262,12 @@ Possible extra rowspan handling
 	margin: 0 auto;
 	width: 50%;
 	background: maroon;
-	background: var(--bg-outdated);
+	background: var(--outdated-bg);
 	color: white;
-	color: var(--text-outdated);
+	color: var(--outdated-text);
 	border-radius: 1em;
 	box-shadow: 0 0 1em red;
-	box-shadow: 0 0 1em var(--shadow-outdated);
+	box-shadow: 0 0 1em var(--outdated-shadow);
 	padding: 2em;
 	text-align: center;
 	z-index: 2;
@@ -1274,7 +1275,7 @@ Possible extra rowspan handling
 
 .outdated-warning a#outdated-note {
 	color: white;
-	color: var(--text-outdated);
+	color: var(--outdated-text);
 }
 .outdated-warning a#outdated-note:hover {
 	background: transparent;
@@ -1282,7 +1283,7 @@ Possible extra rowspan handling
 
 .edited-rec-warning {
 	background: darkorange;
-	background: var(--bg-editedrec);
+	background: var(--editedrec-bg);
 	box-shadow: 0 0 1em;
 }
 
@@ -1295,7 +1296,7 @@ Possible extra rowspan handling
 	padding: 0.25em 0.5em;
 	background: transparent;
 	color: white;
-	color: var(--text-outdated);
+	color: var(--outdated-text);
 	font:1em sans-serif;
 	text-align:center;
 }

--- a/src/base.css
+++ b/src/base.css
@@ -710,6 +710,11 @@
 		border-style: none;
 	}
 
+	img, svg {
+		/* This isn't color-scheme aware, on purpose. */
+		background: white;
+	}
+
 	/* For autogen numbers, add
 	   .caption::before, figcaption::before { content: "Figure " counter(figure) ". "; }
 	*/

--- a/src/base.css
+++ b/src/base.css
@@ -206,22 +206,6 @@
 			padding-right: 0.2em;
 		}
 
-		#toc-toggle-inline {
-			vertical-align: 0.05em;
-			font-size: 80%;
-			color: gray;
-			color: hsla(203,20%,40%,.7);
-			border-style: none;
-			background: transparent;
-			position: relative;
-		}
-		#toc-toggle-inline:hover:not(:active),
-		#toc-toggle-inline:focus:not(:active) {
-			text-shadow: 1px 1px silver;
-			top: -1px;
-			left: -1px;
-		}
-
 		#toc-nav :active {
 			color: #C00;
 		}

--- a/src/base.css
+++ b/src/base.css
@@ -1281,8 +1281,7 @@ Possible extra rowspan handling
 }
 
 .outdated-warning a#outdated-note {
-	color: white;
-	color: var(--outdated-text);
+	color: currentcolor;
 }
 .outdated-warning a#outdated-note:hover {
 	background: transparent;

--- a/src/base.css
+++ b/src/base.css
@@ -757,8 +757,12 @@
 
 	.issue::before, .issue > .marker,
 	.example::before, .example > .marker,
-	.note::before, .note > .marker {
+	.note::before, .note > .marker,
+	details.note > summary > .marker {
 		text-transform: uppercase;
+	}
+
+	.example::before, .example > .marker {
 		display: block;
 	}
 

--- a/src/base.css
+++ b/src/base.css
@@ -151,8 +151,8 @@
 
 	--indexinfo-text: #707070;
 
-	--propindex-hover-text: black;
-	--propindex-hover-bg: #f7f8f9;
+	--indextable-hover-text: black;
+	--indextable-hover-bg: #f7f8f9;
 
 	--outdatedspec-bg: rgba(0, 0, 0, .5);
 	--outdatedspec-text: black;
@@ -1233,9 +1233,9 @@ Possible extra rowspan handling
 	table.index tr:hover td:not([rowspan]),
 	table.index tr:hover th:not([rowspan]) {
 		color: black;
-		color: var(--propindex-hover-text);
+		color: var(--indextable-hover-text);
 		background: #f7f8f9;
-		background: var(--propindex-hover-bg);
+		background: var(--indextable-hover-bg);
 	}
 
 	/* The link in the first column in the property table (formerly a TD) */

--- a/src/base.css
+++ b/src/base.css
@@ -99,13 +99,6 @@
 
 	--border-algo: #def;
 
-	--text-correction: var(--text);
-	--bg-correction: rgba(255, 255, 0, 0.5);
-	--border-correction: yellow;
-	--text-addition: var(--text);
-	--bg-addition: rgba(0, 255, 0, 0.5);
-	--border-addition: green;
-
 	--text-del: red;
 	--bg-del: transparent;
 	--text-ins: #080;
@@ -470,10 +463,6 @@
 	h5 + h6 {
 		margin-top: 1.2em; /* = 1 x line-height */
 	}
-	h3.dim {
-		opacity: 0.7;
-		font-size: 80%;
-	}
 
 /** Section divider ***********************************************************/
 
@@ -553,30 +542,6 @@
 	 width: 1em;
 	 text-align: right;
 	 line-height: 0.5em;
-	}
-	.correction {
-		color: black;
-		color: var(--text-correction);
-		background: rgba(255, 255, 0, 0.5);
-		background: var(--bg-correction);
-		border-left: 10px solid yellow;
-		border-left: 10px solid var(--border-correction);
-		padding-left: 10px;
-	}
-	p.correction:before {
-		content: "PROPOSED CORRECTION: ";
-	}
-	.addition {
-		color: black;
-		color: var(--text-addition);
-		background: rgba(0, 255, 0, 50%);
-		background: var(--bg-addition);
-		border-left: 10px solid green;
-		border-left: 10px solid var(--border-addition);
-		padding-left: 10px;
-	}
-	p.addition:before {
-		content: "PROPOSED ADDITION: ";
 	}
 
 /** Terminology Markup ********************************************************/

--- a/src/base.css
+++ b/src/base.css
@@ -935,7 +935,7 @@
 		padding: 0.5em;
 		vertical-align: baseline;
 		border-bottom: 1px solid #bbd7e9;
-		border-bottom: 1px solid var(--def-rowborder);
+		border-bottom: 1px solid var(--defrow-border);
 	}
 
 	table.def > tbody > tr:last-child th,


### PR DESCRIPTION
Centralize all colors into a block of variables in `:root`, in preparation for modifying them for dark mode.

All variable usage is accompanied by non-variable light-mode colors as well, for backwards-compat.

Overall usage of colors across the stylesheet was made a bit more consistent, with both fg and bg colors used in a number of places.