### PR TITLE
Dark mode

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -780,6 +780,11 @@
 		border-style: none;
 	}
 
+	img, svg {
+		/* Intentionally not color-scheme aware. */
+		background: white;
+	}
+
 	/* For autogen numbers, add
 	   .caption::before, figcaption::before { content: "Figure " counter(figure) ". "; }
 	*/

--- a/src/base.css
+++ b/src/base.css
@@ -71,6 +71,8 @@
 
 /* Any --*-text not paired with a --*-bg is assumed to have a transparent bg */
 :root {
+	color-scheme: light dark;
+
 	--text: black;
 	--bg: white;
 
@@ -162,6 +164,102 @@
 	--outdated-shadow: red;
 
 	--editedrec-bg: darkorange;
+}
+
+@media (prefers-color-scheme: dark) {
+	:root {
+		--text: #ddd;
+		--bg: #111;
+
+		--logo-bg: #1a5e9a;
+		--logo-active-bg: #c00;
+		--logo-text: white;
+
+		--tocnav-normal-text: #999;
+		--tocnav-normal-bg: var(--bg);
+		--tocnav-hover-text: var(--tocnav-normal-text);
+		--tocnav-hover-bg: #080808;
+		--tocnav-active-text: #f44;
+		--tocnav-active-bg: var(--tocnav-normal-bg);
+
+		--tocsidebar-text: var(--text);
+		--tocsidebar-bg: #080808;
+		--tocsidebar-shadow: rgba(255,255,255,.1);
+		--tocsidebar-heading-text: hsla(203,20%,40%,.7);
+
+		--toclink-text: var(--text);
+		--toclink-underline: #6af;
+		--toclink-visited-text: var(--toclink-text);
+		--toclink-visited-underline: #054572;
+
+		--heading-text: #8af;
+
+		--hr-text: var(--text);
+
+		--algo-border: #456;
+
+		--del-text: #f44;
+		--del-bg: transparent;
+		--ins-text: #4a4;
+		--ins-bg: transparent;
+
+		--a-normal-text: #6af;
+		--a-normal-underline: #555;
+		--a-visited-text: var(--a-normal-text);
+		--a-visited-underline: var(--a-normal-underline);
+		--a-hover-bg: rgba(25%, 25%, 25%, .2);
+		--a-active-text: #f44;
+		--a-active-underline: var(--a-active-text);
+
+		--blockquote-border: silver;
+		--blockquote-bg: #181818;
+		--blockquote-text: var(--text);
+
+		--issue-border: #e05252;
+		--issue-bg: #181818;
+		--issue-text: var(--text);
+		--issueheading-text: hsl(0deg, 70%, 70%);
+
+		--example-border: hsl(50deg, 90%, 60%);
+		--example-bg: #181818;
+		--example-text: var(--text);
+		--exampleheading-text: hsl(50deg, 70%, 70%);
+
+		--note-border: hsl(120deg, 100%, 35%);
+		--note-bg: #181818;
+		--note-text: var(--text);
+		--noteheading-text: hsl(120, 70%, 70%);
+		--notesummary-underline: silver;
+
+		--advisement-border: orange;
+		--advisement-bg: #222218;
+		--advisement-text: var(--text);
+		--advisementheading-text: #f84;
+
+		--warning-border: red;
+		--warning-bg: hsla(40,100%,20%,0.95);
+		--warning-text: var(--text);
+
+		--def-border: #8ccbf2;
+		--def-bg: #080818;
+		--def-text: var(--text);
+		--defrow-border: #136;
+
+		--datacell-border: silver;
+
+		--indexinfo-text: #aaa;
+
+		--indextable-hover-text: var(--text);
+		--indextable-hover-bg: #181818;
+
+		--outdatedspec-bg: rgba(255, 255, 255, .5);
+		--outdatedspec-text: black;
+		--outdated-bg: maroon;
+		--outdated-text: white;
+		--outdated-shadow: red;
+
+		--editedrec-bg: darkorange;
+	}
 }
 
 /******************************************************************************/

--- a/src/base.css
+++ b/src/base.css
@@ -90,7 +90,7 @@
 	--tocsidebar-shadow: rgba(0,0,0,.1);
 	--tocsidebar-heading-text: hsla(203,20%,40%,.7);
 
-	--toclink-text: black;
+	--toclink-text: var(--text);
 	--toclink-underline: #3980b5;
 	--toclink-visited-text: var(--toclink-text);
 	--toclink-visited-underline: #054572;


### PR DESCRIPTION
Add dark-mode variants of the colors. I tested them all personally, so afaict they should look good.

Note that Bikeshedded specs have some colors applied on their own, so if you naively spam this in you'll still have some bad color combinations; this should be merged with/after Bikeshed lands its dark-mode styling as well.

This also replaces/closes #184.