### PR TITLE
remove id from outdated link

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -1331,7 +1331,7 @@ Possible extra rowspan handling
 	z-index: 2;
 }
 
-.outdated-warning a#outdated-note {
+.outdated-warning a {
 	color: currentcolor;
 	background: transparent;
 }

--- a/src/fixup.js
+++ b/src/fixup.js
@@ -239,7 +239,6 @@
       frag.appendChild(heading);
 
       var anchor = document.createElement("a");
-      anchor.id = "outdated-note";
       anchor.href = currentSpec.latestUrl;
       anchor.innerText = currentSpec.latestUrl + ".";
 


### PR DESCRIPTION
As @tabatkins noted, the link in the warning has a weird id for no good reason. We can get rid of it.

Fix #200 