### PR TITLE
Auto-generate labels for amendments.

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -897,6 +897,7 @@
 		border-color: var(--amendment-border);
 		background: #F5F0FF;
 		background: var(--amendment-bg);
+		counter-increment: amendment;
 	}
 	.amendment.proposed, .correction.proposed, .addition.proposed {
 		border-style: solid;
@@ -919,6 +920,11 @@
 	details.addition.proposed > summary::before, details.addition.proposed > summary > .marker {
 		font-weight: bold;
 	}
+
+	.correction::before { content: 'Candidate Correction ' counter(amendment) ': '; }
+	.addition::before   { content: 'Candidate Addition '   counter(amendment) ': '; }
+	.proposed.correction::before { content: 'Proposed Correction ' counter(amendment) ': '; }
+	.proposed.addition::before   { content: 'Proposed Addition '   counter(amendment) ': '; }
 
 /** Spec Obsoletion Notice ****************************************************/
 	/* obnoxious obsoletion notice for older/abandoned specs. */

--- a/src/readme.html
+++ b/src/readme.html
@@ -476,7 +476,6 @@ Section Numbers and Anchoring</h3>
   what, exactly, is being added.)
 
   <div class="correction" id="c1">
-    <span class="marker">Candidate Correction 1:</span>
     Explanation of the change, maybe link to related discussion.
 
     <blockquote>
@@ -496,7 +495,6 @@ Section Numbers and Anchoring</h3>
   but worse at showing the edits together.</ins>
 
   <div class="correction" id="c2">
-    <span class="marker">Candidate Correction 2:</span>
     Explanation of the change, maybe link to related discussion.
   </div>
 
@@ -576,7 +574,6 @@ Section Numbers and Anchoring</h3>
   to distinguish these different types of changes.
 
   <div class="correction" id="c3">
-    <span class="marker">Candidate Correction 3:</span>
     Explanation of the correction, maybe link to related discussion.
   </div>
 
@@ -584,7 +581,6 @@ Section Numbers and Anchoring</h3>
       improving the specification of an existing feature.
 
   <div class="addition" id="c4">
-    <span class="marker">Candidate Addition 4:</span>
     Explanation of the addition, maybe link to related discussion and motivation.
     <blockquote>
       <dl>
@@ -604,7 +600,6 @@ Section Numbers and Anchoring</h3>
   must also be marked <code>.proposed</code>.
 
   <div class="correction proposed" id="c5">
-    <span class="marker">Proposed Correction 5:</span>
     Explanation of the change, maybe link to related discussion.
 
     <blockquote>


### PR DESCRIPTION
This uses generated content to automatically label the proposed/candidate changes, as seems to be expected by the mockups. It uses a single counter for all types of changes: alternatives would be to have independent counters per change type or to not number them at all.

My concern with doing this, rather than inlining the labels with class=marker as in the [current readme.html examples](http://fantasai.inkedblade.net/style/design/w3c-restyle/2020/readme#amendment), is whether the text is available to screenreaders. (Generated content is *supposed* to work with screenreaders per spec, but there's been a lot of problems with it. So currently the base styles don't use generated content for similar labels on notes/issues/etc.)