### PR TITLE
Remove the manual background-color on <html>, so darkmode doesn't break.

### DIFF
--- a/src/W3C-UD.css
+++ b/src/W3C-UD.css
@@ -9,5 +9,5 @@ body {
 }
 
 html {
-  background: white url(https://www.w3.org/StyleSheets/TR/2016/logos/UD-watermark);
+  background-image: url(https://www.w3.org/StyleSheets/TR/2016/logos/UD-watermark);
 }

--- a/src/cg-draft.css
+++ b/src/cg-draft.css
@@ -27,6 +27,6 @@ body {
 }
 
 html {
-    background: white url(https://www.w3.org/StyleSheets/TR/2016/logos/UD-watermark);
+    background-image: url(https://www.w3.org/StyleSheets/TR/2016/logos/UD-watermark);
     background-repeat: repeat-x;
 }


### PR DESCRIPTION
The UD and cg-draft stylesheets, when specifying the "unofficial draft" repeating backgrounds, also specify the background color to be specifically white. This breaks darkmode styles.

The bg image should still be fine against a black bg; if we do end up wanting a slight alternate, we can provide one, but this PR is necessary *now* to fix broken darkmoded specs.