### PR TITLE
Actually set the page background color

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -179,6 +179,13 @@
 /*                                   Body                                     */
 /******************************************************************************/
 
+	html {
+		color: black;
+		color: var(--text);
+		background-color: white;
+		background-color: var(--bg);
+	}
+
 	body {
 		counter-reset: example figure issue;
 
@@ -197,10 +204,7 @@
 		overflow-wrap: break-word;
 
 		/* Colors */
-		color: black;
-		color: var(--text);
-		background: white top left fixed no-repeat;
-		background-color: var(--bg);
+		background: transparent top left fixed no-repeat;
 		background-size: 25px auto;
 	}
 


### PR DESCRIPTION
Currently the page background color is set on `body`, but further status-specific rules end up overriding that to transparent, so the specified color never gets used at all.  (And thus, can't be set differently by darkmode styles altering the `--bg` variable.)  I moved it to `html` instead, and moved the 'color' property as well, so they remain paired on the same element.

(Note that the `body` background is *not* generally lifted up to the canvas; some statuses apply the "UNOFFICIAL DRAFT" image via an `html` background, which overrides that. So setting bg color on the `html` is slightly better anyway, at least from a theoretical standpoint.)