### PR TITLE
Switch watermark back to x+y repeating

### DIFF
--- a/src/W3C-UD.css
+++ b/src/W3C-UD.css
@@ -5,7 +5,7 @@
 
 body {
   background: url(https://www.w3.org/StyleSheets/TR/2016/logos/UD) no-repeat fixed,
-              url(https://www.w3.org/StyleSheets/TR/2016/logos/UD-watermark) repeat-x;
+              url(https://www.w3.org/StyleSheets/TR/2016/logos/UD-watermark);
   background-image: url(url(https://www.w3.org/StyleSheets/TR/2016/logos/UD),
                     var(--unofficial-watermark);
   background-color: var(--bg);


### PR DESCRIPTION
It was switched to just repeating in the x direction in 718b5a3277aa8c65efe97ca0a96ca2f6ae933e91, but that is a change in behavior (and means you won't see the watermark if you get linked further into the document).