### PR TITLE
Use more specific markup for ins/del related to amendments

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -21,7 +21,7 @@
  *   - .figure and .caption (HTML4) and figure and figcaption (HTML5)
  *     -> .sidefigure for right-floated figures
  *   - ins/del
- *     -> ins/del[cite=#c???] for candidate and proposed changes (amendments)
+ *     -> ins/del[cite] for candidate and proposed changes (amendments)
  *
  * Code
  *   - pre and code
@@ -601,13 +601,13 @@
 
 	/* for amendments (candidate/proposed changes) */
 	.amendment ins, .correction ins, .addition ins,
-	ins[cite^=#c] { text-decoration-style: dotted; }
+	ins[cite] { text-decoration-style: dotted; }
 	.amendment del, .correction del, .addition del,
-	del[cite^=#c] { text-decoration-style: dotted; }
+	del[cite] { text-decoration-style: dotted; }
 	.amendment.proposed ins, .correction.proposed ins, .addition.proposed ins,
-	ins[cite^=#c].proposed { text-decoration-style: double; }
+	ins[cite].proposed { text-decoration-style: double; }
 	.amendment.proposed del, .correction.proposed del, .addition.proposed del,
-	del[cite^=#c].proposed { text-decoration-style: double; }
+	del[cite].proposed { text-decoration-style: double; }
 
 /** Miscellaneous improvements to inline formatting ***************************/
 

--- a/src/base.css
+++ b/src/base.css
@@ -21,7 +21,7 @@
  *   - .figure and .caption (HTML4) and figure and figcaption (HTML5)
  *     -> .sidefigure for right-floated figures
  *   - ins/del
- *     -> ins/del.c### for candidate and proposed changes (amendments)
+ *     -> ins/del[cite=#c???] for candidate and proposed changes (amendments)
  *
  * Code
  *   - pre and code
@@ -601,13 +601,13 @@
 
 	/* for amendments (candidate/proposed changes) */
 	.amendment ins, .correction ins, .addition ins,
-	ins[class^=c] { text-decoration-style: dotted; }
+	ins[cite^=#c] { text-decoration-style: dotted; }
 	.amendment del, .correction del, .addition del,
-	del[class^=c] { text-decoration-style: dotted; }
+	del[cite^=#c] { text-decoration-style: dotted; }
 	.amendment.proposed ins, .correction.proposed ins, .addition.proposed ins,
-	ins[class^=c].proposed { text-decoration-style: double; }
+	ins[cite^=#c].proposed { text-decoration-style: double; }
 	.amendment.proposed del, .correction.proposed del, .addition.proposed del,
-	del[class^=c].proposed { text-decoration-style: double; }
+	del[cite^=#c].proposed { text-decoration-style: double; }
 
 /** Miscellaneous improvements to inline formatting ***************************/
 

--- a/src/fixup.js
+++ b/src/fixup.js
@@ -135,8 +135,8 @@
   /* Amendment Diff Toggling */
   var showDiff = function(event) {
     var a = event.target.parentElement.parentElement;
-    var ins = document.querySelectorAll("ins." + a.id + ", #" + a.id + " ins" );
-    var del = document.querySelectorAll("del." + a.id + ", #" + a.id + " del" );
+    var ins = document.querySelectorAll("ins[cite=#" + a.id + "], #" + a.id + " ins" );
+    var del = document.querySelectorAll("del[cite=#" + a.id + "], #" + a.id + " del" );
     ins.forEach( function(e) { e.hidden = false; e.removeAttribute('style') });
     del.forEach( function(e) { e.hidden = false; e.removeAttribute('style') });
     a.querySelectorAll("button[value=diff]")[0].disabled = true;
@@ -145,8 +145,8 @@
   }
   var showOld = function(event) {
     var a = event.target.parentElement.parentElement;
-    var ins = document.querySelectorAll("ins." + a.id + ", #" + a.id + " ins" );
-    var del = document.querySelectorAll("del." + a.id + ", #" + a.id + " del" );
+    var ins = document.querySelectorAll("ins[cite=#" + a.id + "], #" + a.id + " ins" );
+    var del = document.querySelectorAll("del[cite=#" + a.id + "], #" + a.id + " del" );
     ins.forEach( function(e) { e.hidden = true;  e.removeAttribute('style') });
     del.forEach( function(e) { e.hidden = false; e.style.all = 'unset' });
     a.querySelectorAll("button[value=diff]")[0].disabled = false;
@@ -155,8 +155,8 @@
   }
   var showNew = function(event) {
     var a = event.target.parentElement.parentElement;
-    var ins = document.querySelectorAll("ins." + a.id + ", #" + a.id + " ins" );
-    var del = document.querySelectorAll("del." + a.id + ", #" + a.id + " del" );
+    var ins = document.querySelectorAll("ins[cite=#" + a.id + "], #" + a.id + " ins" );
+    var del = document.querySelectorAll("del[cite=#" + a.id + "], #" + a.id + " del" );
     ins.forEach( function(e) { e.hidden = false; e.style.all = 'unset'      });
     del.forEach( function(e) { e.hidden = true;  e.removeAttribute('style') });
     a.querySelectorAll("button[value=diff]")[0].disabled = false;
@@ -165,8 +165,8 @@
   }
   var amendments = document.querySelectorAll('[id].amendment, [id].correction, [id].addition');
   amendments.forEach( function(a) {
-    var ins = document.querySelectorAll("ins." + a.id + ", #" + a.id + " ins" );
-    var del = document.querySelectorAll("del." + a.id + ", #" + a.id + " del" );
+    var ins = document.querySelectorAll("ins[cite=#" + a.id + "], #" + a.id + " ins" );
+    var del = document.querySelectorAll("del[cite=#" + a.id + "], #" + a.id + " del" );
     if (ins.length == 0 && del.length == 0) { return; }
 
     var tbar = document.createElement('div');

--- a/src/readme.html
+++ b/src/readme.html
@@ -489,10 +489,10 @@ Section Numbers and Anchoring</h3>
     </blockquote>
   </div>
 
-  <p>And here’s a<ins class=c2>n</ins> <del class=c2>deletion</del>
-  <ins class=c2>insertion</ins> to show how they both look
+  <p>And here’s a<ins cite=#c2>n</ins> <del cite=#c2>deletion</del>
+  <ins cite=#c2>insertion</ins> to show how they both look
   when used outside the box.
-  <ins class=c2>Out-of-box revision markup is better at showing edits in context,
+  <ins cite=#c2>Out-of-box revision markup is better at showing edits in context,
   but worse at showing the edits together.</ins>
 
   <div class="correction" id="c2">
@@ -514,8 +514,8 @@ Section Numbers and Anchoring</h3>
   <p><strong>The amendment box <em>must</em> have
   an <code>id</code> value beginning with <code>c</code>
   and each <code>&lt;ins></code>/<code>&lt;del></code> change associated with it
-  but not contained by it <em>must</em> have a <code>class</code>
-  matching the ID.</strong>
+  but not contained by it <em>must</em> have a <code>cite</code> attribute
+  linking to the ID.</strong>
   Provided correct <code>&lt;ins></code>/<code>&lt;del></code> markup,
   JavaScript support via <code>fixup.js</code> will allow swapping
   between the original and altered wording.
@@ -557,10 +557,10 @@ Section Numbers and Anchoring</h3>
       Explanation of the change, maybe link to related discussion.
     &lt;/div>
 
-    &lt;p>And here’s a&lt;ins class=c2>n&lt;/ins> &lt;del class=c2>deletion&lt;/del>
-    &lt;ins class=c2>insertion&lt;/ins> to show how they both look
+    &lt;p>And here’s a&lt;ins cite=#c2>n&lt;/ins> &lt;del cite=#c2>deletion&lt;/del>
+    &lt;ins cite=#c2>insertion&lt;/ins> to show how they both look
     when used outside the box.
-    &lt;ins class=c2>Out-of-box revision markup is better at showing edits in context,
+    &lt;ins cite=#c2>Out-of-box revision markup is better at showing edits in context,
     but worse at showing the edits together.&lt;/ins>
     </pre>
   </div>
@@ -580,7 +580,7 @@ Section Numbers and Anchoring</h3>
     Explanation of the correction, maybe link to related discussion.
   </div>
 
-  <p>Here’s a<ins class=c3>n</ins> <del class=c3>deletion</del> <ins class=c3>insertion</ins>
+  <p>Here’s a<ins cite=#c3>n</ins> <del cite=#c3>deletion</del> <ins cite=#c3>insertion</ins>
       improving the specification of an existing feature.
 
   <div class="addition" id="c4">

--- a/src/readme.html
+++ b/src/readme.html
@@ -512,7 +512,7 @@ Section Numbers and Anchoring</h3>
   to readers of the affected sections of the document.
 
   <p><strong>The amendment box <em>must</em> have
-  an <code>id</code> value beginning with <code>c</code>
+  an <code>id</code> value
   and each <code>&lt;ins></code>/<code>&lt;del></code> change associated with it
   but not contained by it <em>must</em> have a <code>cite</code> attribute
   linking to the ID.</strong>


### PR DESCRIPTION
Instead of the idiosyncratic use of the class attribute to track which ins/del belong to which amendment, use the cite attribute, which is made for that:

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins#attr-cite
https://html.spec.whatwg.org/#attr-mod-cite

This change can be made without regards for compatibility as this style of markup has not yet been deployed.