### PR TITLE
Fix bug in diffing code

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -598,8 +598,8 @@
 		background: var(--ins-bg);
 		text-decoration: underline;
 	}
-	ins.diff-inactive,
-	del.diff-inactive {
+	ins:not([hidden]).diff-inactive,
+	del:not([hidden]).diff-inactive {
 		all: unset;
 	}
 	ins:not(.diff-inactive) *,


### PR DESCRIPTION
c95569da520715b338cd0173400ca399adba0ddd introduced a styling bug, breaking the ability of the diff viewer to hiden either the before or the after version. This fixes it.

Sorry for not catching this earlier.