### PR TITLE
double up a class selector to increase specificity

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -602,8 +602,8 @@
 	del:not([hidden]).diff-inactive {
 		all: unset;
 	}
-	ins:not(.diff-inactive) *,
-	del:not(.diff-inactive) * {
+	ins:not(.diff-inactive):not(.diff-inactive) *,
+	del:not(.diff-inactive):not(.diff-inactive) * { /* doubling up the class selector for specificity */
 		color: inherit;
 	}
 


### PR DESCRIPTION
Otherwise (depending on stylesheet order) it looses against `a[href]`, even though we want it to win.