### PR TITLE
Don't forcibly show hidden details elements

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -937,7 +937,7 @@
 /** Spec Obsoletion Notice ****************************************************/
 	/* obnoxious obsoletion notice for older/abandoned specs. */
 
-	details {
+	details:not([hidden]) {
 		display: block;
 	}
 	summary {


### PR DESCRIPTION
The details element is `display: block` by default. We can include a redundant rule in the stylesheet for compat reasons, but it should be done in a way that doesn't cancel the fact that elements with the `hidden` attribute are expected to be `display:none`.