### PR TITLE
Improvements to link styling thanks to advances in CSS! #222 #103

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -115,9 +115,9 @@
 	--ins-bg: transparent;
 
 	--a-normal-text: #034575;
-	--a-normal-underline: #bbb;
+	--a-normal-underline: #707070;
 	--a-visited-text: var(--a-normal-text);
-	--a-visited-underline: #707070;
+	--a-visited-underline: #bbb;
 	--a-hover-bg: rgba(75%, 75%, 75%, .25);
 	--a-active-text: #c00;
 	--a-active-underline: #c00;
@@ -667,34 +667,28 @@
 	a[href] {
 		color: #034575;
 		color: var(--a-normal-text);
-		text-decoration: none;
-		border-bottom: 1px solid #707070;
-		border-bottom: 1px solid var(--a-normal-underline);
-		/* Need a bit of extending for it to look okay */
-		padding: 0 1px 0;
-		margin: 0 -1px 0;
+		text-decoration: underline #707070;
+		text-decoration: underline var(--a-normal-underline);
+		text-decoration-skip-ink: none;
 	}
 	a:visited {
 		color: #034575;
 		color: var(--a-visited-text);
-		border-bottom-color: #bbb;
-		border-bottom-color: var(--a-visited-underline);
+		text-decoration-color: #bbb;
+		text-decoration-color: var(--a-visited-underline);
 	}
 
-	/* Use distinguishing colors when user is interacting with the link */
+	/* Indicate interaction with the link */
 	a[href]:focus,
 	a[href]:hover {
-		background: #f8f8f8;
-		background: rgba(75%, 75%, 75%, .25);
-		background: var(--a-hover-bg);
-		border-bottom-width: 3px;
-		margin-bottom: -2px;
+		text-decoration-thickness: 2px;
+		text-decoration-skip-ink: none;
 	}
 	a[href]:active {
 		color: #c00;
 		color: var(--a-active-text);
-		border-color: #c00;
-		border-color: var(--a-active-underline);
+		text-decoration-color: #c00;
+		text-decoration-color: var(--a-active-underline);
 	}
 
 	/* Backout above styling for W3C logo */
@@ -1177,20 +1171,36 @@ Possible extra rowspan handling
 
 	.toc a {
 		/* More spacing; use padding to make it part of the click target. */
-		padding-top: 0.1rem;
+		padding: 0.1rem 1px 0;
 		/* Larger, more consistently-sized click target */
 		display: block;
+		/* Switch to using border-bottom */
+		text-decoration: none;
+		border-bottom: 1px solid;
+		border-bottom: 1px solid;
 		/* Reverse color scheme */
 		color: black;
 		color: var(--toclink-text);
+		text-decoration-color: #3980b5;
+		text-decoration-color: var(--toclink-underline);
 		border-color: #3980b5;
 		border-color: var(--toclink-underline);
 	}
 	.toc a:visited {
 		color: black;
 		color: var(--toclink-visited-text);
+		text-decoration-color: #054572;
+		text-decoration-color: var(--toclink-visited-underline);
 		border-color: #054572;
 		border-color: var(--toclink-visited-underline);
+	}
+	.toc a:focus,
+	.toc a:hover {
+		background: #f8f8f8;
+		background: rgba(75%, 75%, 75%, .25);
+		background: var(--a-hover-bg);
+		border-bottom-width: 3px;
+		margin-bottom: -2px;
 	}
 	.toc a:not(:focus):not(:hover) {
 		/* Allow colors to cascade through from link styling */


### PR DESCRIPTION
This switches us back to using actual underlines everywhere except the table of contents, now that there's widespread support for changing the underline color via `text-decoration-color`.

It also switches the darker underline color to unvisited links, so that visited links (which you're presumably less interested to click on) have the subtler light gray color.

You can see the result at https://fantasai.inkedblade.net/style/design/w3c-restyle/2020/readme#expanding-text and comparing to https://fantasai.inkedblade.net/style/design/w3c-restyle/2016/sample#expanding-text