### PR TITLE
fixup.js: exclude non-stylesheet link for darkCss

### DIFF
--- a/src/fixup.js
+++ b/src/fixup.js
@@ -298,7 +298,7 @@
   }
 
   /* Dark mode toggle */
-  const darkCss = document.querySelector('link[href^="https://www.w3.org/StyleSheets/TR/2016/dark"]');
+  const darkCss = document.querySelector('link[rel~="stylesheet"][href^="https://www.w3.org/StyleSheets/TR/2016/dark"]');
   if (darkCss) {
     const colorScheme = localStorage.getItem("tr-theme") || "auto";
     darkCss.disabled = colorScheme === "light";


### PR DESCRIPTION
ReSpec's stylesheet loading includes some `link[rel=preload]`, so `fixup.js` ends up adding `media` attribute to preloads instead of actual stylesheet.