### PR TITLE
Update cryd-6.5.2.html

### DIFF
--- a/p2021mockup/cryd-6.5.2.html
+++ b/p2021mockup/cryd-6.5.2.html
@@ -217,7 +217,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   </p>
   <p style='padding: 0.5ex; border: 2px solid red; background: red; color: white; font-weight: bold; text-align: center'>
     This document is NOT an official W3C technical report.<br>It is a a sample document meant to illustrate the style for Process 2021.
-</p><p>Publication as a Candidate Registry Draft does not imply endorsement by 
+</p><p>Publication as a Candidate Registry does not imply endorsement by 
   <abbr title="World Wide Web Consortium">W3C</abbr> and its Members. A Candidate Registry Draft integrates changes from the previous Candidate Registry that the Working Group intends to include in a subsequent Candidate Registry Snapshot.</p>
   (@@choose one of the 2 following paragraphs)
   <p>


### PR DESCRIPTION
In [Candidate Recommendation Draft](https://w3c.github.io/tr-design/p2021mockup/crd-6.3.8.2.html) document, both online and mockup, CRD is treated as a special stage of 'CR', so the sentence is:
```
Publication as a Candidate Recommendation does not ...
```

To be aligned with above, for CRYD, the sentence should be :
```
Publication as a Candidate Registry does not ...
```