### PR TITLE
Update cry-6.5.2.html

### DIFF
--- a/p2021mockup/cry-6.5.2.html
+++ b/p2021mockup/cry-6.5.2.html
@@ -217,7 +217,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   </p>
   <p style='padding: 0.5ex; border: 2px solid red; background: red; color: white; font-weight: bold; text-align: center'>
     This document is NOT an official W3C technical report.<br>It is a a sample document meant to illustrate the style for Process 2021.
-</p><p>Publication as a Candidate Registry does not imply endorsement by 
+</p><p>Publication as a Candidate Registry Snapshot does not imply endorsement by 
   <abbr title="World Wide Web Consortium">W3C</abbr> and its Members. A Candidate Registry Snapshot has received <a
   href="https://www.w3.org/2021/Process-20210923/#dfn-wide-review">wide review</a>.</p>
   (@@choose one of the 2 following paragraphs. Note that pubrules only checks for the date anyway.)

--- a/p2021mockup/cry-6.5.2.html
+++ b/p2021mockup/cry-6.5.2.html
@@ -151,7 +151,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
     <a class="logo" href="https://www.w3.org/"><img alt="W3C" width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C"></a> <h1 id="title" class="title">Ready-made Counter Styles</h1>
 
     <p id='w3c-state'>
-      <a href='https://www.w3.org/standards/types#CRY'>W3C Candidate Registry</a>
+      <a href='https://www.w3.org/standards/types#CRY'>W3C Candidate Registry Snapshot</a>
       <time class="dt-published" datetime="2021-09-15">15 September 2021</time>
     </p>
     <details open>
@@ -211,7 +211,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   <p>This document describes counter styles used by various cultures around the world and can be used as a reference for those wishing to define user-defined counter styles for CSS. The content of this document was originally part of the CSS Lists and Counters specification, but is now published as a standalone document by the <abbr title="World Wide Web Consortium">W3C</abbr> Internationalization Working Group. It is expected that the document will be updated from time to time to include new information.</p>
 <p>
     This document was published by the <a href="https://www.w3.org/groups/wg/i18n-core">Internationalization Working Group</a> as a
-    Candidate Registry using the <a
+    Candidate Registry Snapshot using the <a
     href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Registry
     track</a>.
   </p>


### PR DESCRIPTION
In **Candidate Registry Snapshot** document, the `w3c-state` and 'publish as ...' should mention the text **Snapshot**, just as https://w3c.github.io/tr-design/p2021mockup/cr-6.3.8.1.html

cc @deniak 