### PR TITLE
set minimum heigh for TOC items (WCAG 2.2 success criterion)

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -1231,6 +1231,9 @@ Possible extra rowspan handling
 	.toc {
 		line-height: 1.1em; /* consistent spacing */
 	}
+	.toc > li {
+		min-height: 24px; /* minimum target size success criterion */
+	}
 
 	/* ToC not indented until third level, but font style & margins show hierarchy */
 	.toc > li             { font-weight: bold;   }


### PR DESCRIPTION
That PR addresses the new [target size](https://www.w3.org/TR/WCAG22/#target-size-minimum) success criterion introduced in WCAG 2.2.

Fix #318