### PR TITLE
Update base.css for included SVG content

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -757,7 +757,8 @@
 		margin: 2.5em 0;
 	}
 	.figure img,    .sidefigure img,    figure img,
-	.figure object, .sidefigure object, figure object {
+	.figure object, .sidefigure object, figure object
+        .figure svg,    .sidefigure svg,    figure svg {
 		max-width: 100%;
 		margin: auto;
 		height: auto;

--- a/src/base.css
+++ b/src/base.css
@@ -757,7 +757,7 @@
 		margin: 2.5em 0;
 	}
 	.figure img,    .sidefigure img,    figure img,
-	.figure object, .sidefigure object, figure object
+	.figure object, .sidefigure object, figure object,
         .figure svg,    .sidefigure svg,    figure svg {
 		max-width: 100%;
 		margin: auto;


### PR DESCRIPTION
There may be good reason to directly _include_ and SVG content, instead of referring to an external file via `img` or `object`. The size constraints for those cases should not be different, however.