### PR TITLE
Fix dl.switch incrementing list items

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -584,16 +584,13 @@
 	@supports (list-style: "\21AA  ") {
 		dl.switch > dt {
 			display: list-item;
+			counter-increment: list-item 0;
 			list-style: "\21AA  ";
 			margin-left: -1.5em;
 			text-indent: 0;
 		}
 		dl.switch > dt::before {
 			content: none;
-		}
-		dl {
-			/* don't accidentally increment the implied list-item counter */
-			counter-reset: list-item;
 		}
 	}
 


### PR DESCRIPTION
The previous code *should* have worked to prevent dl.switch items from incrementing the implied list-item counter of parent lists, but at least in Chrome, that's not happening currently. (Probably our impl of list-item + `ol` is still a little busted.)

Instead of scoping the counter, which prevents ancestors from *seeing* the value get incremented, I'm changing it to just directly not increment the counter. No need to scope, then.

(See https://github.com/speced/bikeshed/issues/2832 for a live bug report on this.)