### PR TITLE
Added class="removeOnSave" to amendments button

### DIFF
--- a/src/fixup.js
+++ b/src/fixup.js
@@ -178,7 +178,7 @@
     if (ins.length == 0 && del.length == 0) { return; }
 
     var tbar = document.createElement('div');
-    tbar.lang = 'en'; tbar.class = 'amendment-toggles';
+    tbar.lang = 'en'; tbar.className = 'amendment-toggles removeOnSave';
 
     var toggle = document.createElement('button');
     toggle.value = 'diff'; toggle.innerHTML = 'Show Change'; toggle.disabled = true;


### PR DESCRIPTION
fixup.js adds buttons to candidate corrections/amendments. When spec is using respec, fixup.js adds them on load, and export feature exports html with them. So, displaying exported html results to have two sets of buttons.
Adding removeOnSave, respec will remove buttons on export, which will fix the issue of having two sets of buttons.