### PR TITLE
Improve visual separation of blocks in dark mode

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -798,8 +798,8 @@
 	.issue, .note, .example, .advisement, blockquote,
 	.amendment, .correction, .addition {
 		padding: .5em;
-		border: .5em;
-		border-left-style: solid;
+		border-left: .5em solid;
+		border-bottom: 0.25em solid;
 		page-break-inside: avoid;
 		margin: 1em auto;
 	}


### PR DESCRIPTION
The various blocks have a background color that is visible in light mode. However, in dark mode, the background color is not there. Unfortunately making the color more prominent leads to contrast issues with text, since the text is white instead of black.

Therefore, in dark mode, these boxes have a nearly opaque white-ish background:

```css
--borderedblock-bg: rgba(255, 255, 255, .05);
```

Unfortunately this contrast is barely visible, even for folks like me with good eye-sight.

To improve the visual separation, next to the existing border on the left, also add a border on the bottom of each block. These two borders make visual distinction in dark mode possible, while not being intrusive in light mode.

The reason for editing `base.css` rather than `dark.css` is that we currently have no precedence for overriding styles in `dark.css` other than via CSS variables. Since variables are only used for colors and not stylistic properties, I opted not to touch `dark.css` for this change.