### PR TITLE
Add meaningful text to toc controls

### DIFF
--- a/src/fixup.js
+++ b/src/fixup.js
@@ -15,13 +15,18 @@
     details.open = !localStorage.getItem("tr-metadata") || localStorage.getItem("tr-metadata") === 'true';
   } catch (e) {}; // ignore errors for this interaction
 
+  const tocToggleId = 'toc-toggle';
+  const tocJumpId = 'toc-jump';
+  const tocCollapseId = 'toc-collapse';
+  const tocExpandId = 'toc-expand';
+
   var ESCAPEKEY = 27;
   var collapseSidebarText = '<span aria-hidden="true">←</span> '
-                          + '<span>Collapse Sidebar</span>';
+                          + `<span id="${tocCollapseId}-text">Collapse Sidebar</span>`;
   var expandSidebarText   = '<span aria-hidden="true">→</span> '
-                          + '<span>Pop Out Sidebar</span>';
+                          + `<span id="${tocExpandId}-text">Pop Out Sidebar</span>`;
   var tocJumpText         = '<span aria-hidden="true">↑</span> '
-                          + '<span>Jump to Table of Contents</span>';
+                          + `<span id="${tocJumpId}-text">Jump to Table of Contents</span>`;
 
   var sidebarMedia = window.matchMedia('screen and (min-width: 78em)');
   var autoToggle   = function(e){ toggleSidebar(e.matches) };
@@ -45,13 +50,14 @@
       skipScroll = window.scrollY < headY;
     }
 
-    var toggle = document.getElementById('toc-toggle');
+    var toggle = document.getElementById(tocToggleId);
     var tocNav = document.getElementById('toc');
     if (on) {
       var tocHeight = tocNav.offsetHeight;
       document.body.classList.add('toc-sidebar');
       document.body.classList.remove('toc-inline');
       toggle.innerHTML = collapseSidebarText;
+      toggle.setAttribute('aria-labelledby', `${tocCollapseId}-text`);
       if (!skipScroll) {
         window.scrollBy(0, 0 - tocHeight);
       }
@@ -62,6 +68,7 @@
       document.body.classList.add('toc-inline');
       document.body.classList.remove('toc-sidebar');
       toggle.innerHTML = expandSidebarText;
+      toggle.setAttribute('aria-labelledby', `${tocExpandId}-text`);
       if (!skipScroll) {
         window.scrollBy(0, tocNav.offsetHeight);
       }
@@ -77,7 +84,7 @@
     /* Create the sidebar toggle in JS; it shouldn't exist when JS is off. */
     var toggle = document.createElement('a');
       /* This should probably be a button, but appearance isn't standards-track.*/
-    toggle.id = 'toc-toggle';
+    toggle.id = tocToggleId;
     toggle.class = 'toc-toggle';
     toggle.href = '#toc';
     toggle.innerHTML = collapseSidebarText;
@@ -101,12 +108,13 @@
       document.body.insertBefore(tocNav, document.body.firstChild);
     }
     /* While we're at it, make sure we have a Jump to Toc link. */
-    var tocJump = document.getElementById('toc-jump');
+    var tocJump = document.getElementById(tocJumpId);
     if (!tocJump) {
       tocJump = document.createElement('a');
-      tocJump.id = 'toc-jump';
+      tocJump.id = tocJumpId;
       tocJump.href = '#toc';
       tocJump.innerHTML = tocJumpText;
+      tocJump.setAttribute('aria-labelledby', `${tocJumpId}-text`);
       tocNav.appendChild(tocJump);
     }
 
@@ -115,7 +123,7 @@
 
   var toc = document.getElementById('toc');
   if (toc) {
-    if (!document.getElementById('toc-toggle')) {
+    if (!document.getElementById(tocToggleId)) {
       createSidebarToggle();
     }
     toggleSidebar(sidebarMedia.matches, true);


### PR DESCRIPTION
The current implementation does not have a label for navigation elements, since the text is hidden. Firefox DevTools also claims that the node does not have any label.

Instead, we can use `aria-labelledby` to reference to the hidden element, to override the default text and have proper announcement.

Note that the code uses `const` in this place where others are using `var`. However, at the bottom of this script, we already use `const`, so I figured that the usage is fine.

Fixes #136