### PR TITLE
Add styling for tables

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -1032,39 +1032,6 @@
 /*                                    Tables                                  */
 /******************************************************************************/
 
-	table {
-		border-spacing: 0;
-		border-collapse: collapse;
-		border-bottom: 3px solid var(--table-header-background);
-		position: relative;
-		word-wrap: normal;
-		overflow-wrap: normal;
-		hyphens: manual;
-	}
-	thead {
-		position: sticky;
-		top: 0;
-	}
-	th {
-		background: var(--table-header-background);
-		color: var(--table-header-text);
-		padding: 3px 5px;
-		text-align: left;
-	}
-	th a {
-		color: var(--table-header-text);
-		padding: 3px 5px;
-		text-align: left;
-	}
-	th[scope="row"] {
-		background: inherit;
-		color: inherit;
-		border-top: 1px solid var(--table-row-separator);
-	}
-	td {
-		padding: 3px 10px;
-		border-top: 1px solid var(--table-row-separator);
-	}
 	th, td {
 		text-align: left;
 		text-align: start;
@@ -1131,12 +1098,23 @@
 		 Alternately use class="longlastcol" on tables, to have the last column assume "long".
 	*/
 
+	table {
+		word-wrap: normal;
+		overflow-wrap: normal;
+		hyphens: manual;
+	}
+
 	table.data,
 	table.index {
-		margin: 1em auto;
-		border-collapse: collapse;
-		border: hidden;
 		width: 100%;
+		border-spacing: 0;
+		border-collapse: collapse;
+		border-bottom: 3px solid var(--table-header-background);
+		margin: 1em auto;
+		position: relative;
+		word-wrap: normal;
+		overflow-wrap: normal;
+		hyphens: manual;
 	}
 	table.data caption,
 	table.index caption {
@@ -1163,6 +1141,36 @@
 	table.data  tbody,
 	table.index tbody {
 		border-bottom: 2px solid;
+	}
+
+	table.data  thead,
+	table.index thead {
+		position: sticky;
+		top: 0;
+	}
+
+	table.data  th,
+	table.index th {
+		background: var(--table-header-background);
+		color: var(--table-header-text);
+		text-align: left;
+	}
+
+	table.data  th a,
+	table.index th a {
+		color: var(--table-header-text);
+	}
+
+	table.data  th[scope="row"],
+	table.index th[scope="row"] {
+		background: inherit;
+		color: inherit;
+		border-top: 1px solid var(--table-row-separator);
+	}
+
+	table.data  tr:nth-child(even),
+	table.index tr:nth-child(even) {
+		background: var(--table-row-even);
 	}
 
 	table.data colgroup,

--- a/src/base.css
+++ b/src/base.css
@@ -179,6 +179,11 @@
 	--outdated-shadow: red;
 
 	--editedrec-bg: darkorange;
+
+	--table-header-background: #005a9c;
+	--table-header-text: white;
+	--table-row-even: #f0f6ff;
+	--table-row-separator: #ddd;
 }
 
 /******************************************************************************/
@@ -1027,9 +1032,45 @@
 /*                                    Tables                                  */
 /******************************************************************************/
 
+	table {
+		border-spacing: 0;
+		border-collapse: collapse;
+		border-bottom: 3px solid var(--table-header-background);
+		position: relative;
+		word-wrap: normal;
+		overflow-wrap: normal;
+		hyphens: manual;
+	}
+	thead {
+		position: sticky;
+		top: 0;
+	}
+	th {
+		background: var(--table-header-background);
+		color: var(--table-header-text);
+		padding: 3px 5px;
+		text-align: left;
+	}
+	th a {
+		color: var(--table-header-text);
+		padding: 3px 5px;
+		text-align: left;
+	}
+	th[scope="row"] {
+		background: inherit;
+		color: inherit;
+		border-top: 1px solid var(--table-row-separator);
+	}
+	td {
+		padding: 3px 10px;
+		border-top: 1px solid var(--table-row-separator);
+	}
 	th, td {
 		text-align: left;
 		text-align: start;
+	}
+	tr:nth-child(even) {
+		background: var(--table-row-even);
 	}
 
 /** Property/Descriptor Definition Tables *************************************/
@@ -1089,12 +1130,6 @@
 		 (This will adjust text alignment accordingly.)
 		 Alternately use class="longlastcol" on tables, to have the last column assume "long".
 	*/
-
-	table {
-		word-wrap: normal;
-		overflow-wrap: normal;
-		hyphens: manual;
-	}
 
 	table.data,
 	table.index {

--- a/src/base.css
+++ b/src/base.css
@@ -1036,9 +1036,6 @@
 		text-align: left;
 		text-align: start;
 	}
-	tr:nth-child(even) {
-		background: var(--table-row-even);
-	}
 
 /** Property/Descriptor Definition Tables *************************************/
 

--- a/src/dark.css
+++ b/src/dark.css
@@ -119,4 +119,6 @@ img { background: white; }
 	--outdated-shadow: red;
 
 	--editedrec-bg: darkorange;
+
+	--table-even-rows: #151b23;
 }

--- a/src/dark.css
+++ b/src/dark.css
@@ -120,5 +120,5 @@ img { background: white; }
 
 	--editedrec-bg: darkorange;
 
-	--table-even-rows: #151b23;
+	--table-row-even: #151b23;
 }


### PR DESCRIPTION
This PR effectively upstreams the changes originally part of Respec:
https://github.com/speced/respec/pull/4676

The changes in Respec were removed, to ensure that the default
W3C styles are used. Upstreaming of these changes never
happened, and we currently have manually added these styles
in our base template.

Additionally, for large tables the sticky header is useful. This makes
sure that tables that span more than 1 screen height can still have
meaningful heading text when scrolling down.

Lastly, even rows are now colored. The styles used are those in
Markdown tables on GitHub itself. This works for both light and
dark mode.

Fixes #353