### PR TITLE
Remove “small caps” for <h6> elements

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -477,7 +477,6 @@
 	h3 { font-size: 120%; }
 	h4 { font-weight: bold; }
 	h5 { font-style: italic; }
-	h6 { font-variant: small-caps; }
 	dt { font-weight: bold; }
 
 /** Subheadings ***************************************************************/


### PR DESCRIPTION
The spec uses fake “small caps” for `<h6>` elements. Small caps are generally difficult to read, and with the thinner letter forms of fake small caps, it is even worse.

h4 are already bold, h5 italic, so leaving h6 without special treatment apart from spacing and the § link is probably totally fine.

See: https://github.com/w3c/wcag2ict/issues/771