### PR TITLE
Fix toc-theme-toggle append location prevention

### DIFF
--- a/src/fixup.js
+++ b/src/fixup.js
@@ -19,6 +19,7 @@
   const tocJumpId = 'toc-jump';
   const tocCollapseId = 'toc-collapse';
   const tocExpandId = 'toc-expand';
+  const tocThemeToggle = 'toc-theme-toggle';
 
   var ESCAPEKEY = 27;
 
@@ -389,14 +390,16 @@
         </label>
       `.trim();
     }
-    render.innerHTML = `
-      <a id="toc-theme-toggle" role="radiogroup" aria-label="Select a color scheme">
-        <span aria-hidden="true"><img src="https://www.w3.org/StyleSheets/TR/2021/logos/dark.svg" title="theme toggle icon" /></span>
-        <span>
-        ${["light", "dark", "auto"].map(createOption).join("")}
-        </span>
-      </a>
-    `;
+    if (!document.getElementById(tocThemeToggle)) {
+      render.innerHTML = `
+        <a id="toc-theme-toggle" role="radiogroup" aria-label="Select a color scheme">
+          <span aria-hidden="true"><img src="https://www.w3.org/StyleSheets/TR/2021/logos/dark.svg" title="theme toggle icon" /></span>
+          <span>
+          ${["light", "dark", "auto"].map(createOption).join("")}
+          </span>
+        </a>
+      `;
+    }
     const changeListener = (event) => {
       const { value } = event.target;
       const browserDarkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;

--- a/src/fixup.js
+++ b/src/fixup.js
@@ -390,16 +390,14 @@
         </label>
       `.trim();
     }
-    if (!document.getElementById(tocThemeToggle)) {
-      render.innerHTML = `
-        <a id="toc-theme-toggle" role="radiogroup" aria-label="Select a color scheme">
-          <span aria-hidden="true"><img src="https://www.w3.org/StyleSheets/TR/2021/logos/dark.svg" title="theme toggle icon" /></span>
-          <span>
-          ${["light", "dark", "auto"].map(createOption).join("")}
-          </span>
-        </a>
-      `;
-    }
+    render.innerHTML = `
+      <a id="toc-theme-toggle" role="radiogroup" aria-label="Select a color scheme">
+        <span aria-hidden="true"><img src="https://www.w3.org/StyleSheets/TR/2021/logos/dark.svg" title="theme toggle icon" /></span>
+        <span>
+        ${["light", "dark", "auto"].map(createOption).join("")}
+        </span>
+      </a>
+    `;
     const changeListener = (event) => {
       const { value } = event.target;
       const browserDarkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -418,7 +416,9 @@
     });
 
     var tocNav = document.querySelector('#toc-nav');
-    tocNav.appendChild(...render.children);
+    if (!document.getElementById(tocThemeToggle)) {
+      tocNav.appendChild(...render.children);
+    }
   }
 
 })();


### PR DESCRIPTION
This is a better fix for preventing additional appending of `toc-theme-toggle` than the earlier PR https://github.com/w3c/tr-design/pull/379, because it actually blocks the append. Sorry for missing this the first time.

While this works fine, some refactoring of the code in `if (darkCss) {` would be better, as that would avoid running a number of unnecessary steps. We did not want to do that here but at least wanted to fix the previous issue more effectively.

@deniak 